### PR TITLE
Use the built-in environment variables for the API service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+language: ruby
+sudo: false
+cache: bundler
+rvm:
+- 2.4.5
+before_install:
+- gem update --system
+- gem install bundler
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- "./cc-test-reporter before-build"
+after_script:
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"

--- a/config/collector_definitions.yaml
+++ b/config/collector_definitions.yaml
@@ -4,4 +4,4 @@
 
 ---
 openshift:
-  image: "buildfactory/topological-inventory-ci/topological-inventory-collector-openshift:latest"
+  image: "buildfactory/topological-inventory-ci/topological-inventory-openshift:latest"

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -11,7 +11,7 @@ module TopologicalInventory
     class Worker
       attr_reader :logger
 
-      def initialize(api_base_url: ENV["API_URL"], collector_definitions_file: ENV["CONTAINER_DEFINITIONS_FILE"])
+      def initialize(api_base_url, collector_definitions_file = ENV["COLLECTOR_DEFINITIONS_FILE"])
         @api_base_url = api_base_url
         @collector_definitions_file = collector_definitions_file || TopologicalInventory::Orchestrator.root.join("config/collector_definitions.yaml")
         @logger = ManageIQ::Loggers::Container.new

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -89,12 +89,12 @@ describe TopologicalInventory::Orchestrator::Worker do
       instance.send(:collectors_from_database, db)
 
       expect(db).to eq(
-        "f52ab314d4d6fbaed87261c4a72652bf7a65cf97" => {
+        "f3105d3cdbfcf1c7eb722303a1739955a76b363e" => {
           "endpoint_host"   => "example.com",
           "endpoint_path"   => "/api",
           "endpoint_port"   => 8443,
           "endpoint_scheme" => "https",
-          "image"           => "buildfactory/topological-inventory-ci/topological-inventory-collector-openshift:latest",
+          "image"           => "buildfactory/topological-inventory-ci/topological-inventory-openshift:latest",
           "source_id"       => "2",
           "source_uid"      => "31b5338b-685d-4056-ba39-d00b4d7f19cc",
           "secret"          => {

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -61,7 +61,7 @@ describe TopologicalInventory::Orchestrator::Worker do
 
     it "generates the expected hash" do
       db = {}
-      instance = described_class.new(api_base_url: "http://example.com")
+      instance = described_class.new("http://example.com")
 
       expect(RestClient).to receive(:get).with("http://example.com/source_types").and_return(source_types_response)
       expect(RestClient).to receive(:get).with("http://example.com/source_types/1/sources").and_return(source_types_1_sources_response)
@@ -97,7 +97,7 @@ describe TopologicalInventory::Orchestrator::Worker do
   end
 
   it "#each_resource" do
-    instance = described_class.new
+    instance = described_class.new("http://example.com")
 
     url_1 = "http://example.com/1"
     url_2 = "http://example.com/2"

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,4 +1,14 @@
 describe TopologicalInventory::Orchestrator::Worker do
+  around do |e|
+    ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"] = "example.com"
+    ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"] = "8080"
+
+    e.run
+
+    ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST")
+    ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_PORT")
+  end
+
   context "#collectors_from_database" do
     let(:source_types_response) do
       <<~EOJ
@@ -61,20 +71,20 @@ describe TopologicalInventory::Orchestrator::Worker do
 
     it "generates the expected hash" do
       db = {}
-      instance = described_class.new("http://example.com")
+      instance = described_class.new
 
-      expect(RestClient).to receive(:get).with("http://example.com/source_types").and_return(source_types_response)
-      expect(RestClient).to receive(:get).with("http://example.com/source_types/1/sources").and_return(source_types_1_sources_response)
-      expect(RestClient).to receive(:get).with("http://example.com/sources/1/endpoints").and_return(sources_1_endpoints_response)
-      expect(RestClient).to receive(:get).with("http://example.com/sources/2/endpoints").and_return(sources_2_endpoints_response)
-      expect(RestClient).to receive(:get).with("http://example.com/authentications?resource_type=Endpoint&resource_id=1").and_return(endpoints_1_authentications_response)
-      expect(RestClient).to receive(:get).with("http://example.com/internal/v0.0/authentications/1?expose_encrypted_attribute[]=password").and_return({"username" => "USER", "password" => "PASS"}.to_json)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types").and_return(source_types_response)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types/1/sources").and_return(source_types_1_sources_response)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/sources/1/endpoints").and_return(sources_1_endpoints_response)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/sources/2/endpoints").and_return(sources_2_endpoints_response)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=1").and_return(endpoints_1_authentications_response)
+      expect(RestClient).to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/1?expose_encrypted_attribute[]=password").and_return({"username" => "USER", "password" => "PASS"}.to_json)
 
-      expect(RestClient).not_to receive(:get).with("http://example.com/source_types/2/sources")
-      expect(RestClient).not_to receive(:get).with("http://example.com/authentications?resource_type=Endpoint&resource_id=8")
-      expect(RestClient).not_to receive(:get).with("http://example.com/authentications?resource_type=Endpoint&resource_id=9")
-      expect(RestClient).not_to receive(:get).with("http://example.com/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password")
-      expect(RestClient).not_to receive(:get).with("http://example.com/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/source_types/2/sources")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=8")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=9")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password")
 
       instance.send(:collectors_from_database, db)
 
@@ -97,11 +107,11 @@ describe TopologicalInventory::Orchestrator::Worker do
   end
 
   it "#each_resource" do
-    instance = described_class.new("http://example.com")
+    instance = described_class.new
 
-    url_1 = "http://example.com/1"
-    url_2 = "http://example.com/2"
-    url_3 = "http://example.com/3"
+    url_1 = "http://example.com:8080/1"
+    url_2 = "http://example.com:8080/2"
+    url_3 = "http://example.com:8080/3"
     response_1 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_2, "prev" => nil}, "data" => [1, 2, 3]}.to_json
     response_2 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_3, "prev" => url_1}, "data" => [4, 5, 6]}.to_json
     response_3 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => nil, "prev" => url_2}, "data" => [7, 8]}.to_json
@@ -111,5 +121,36 @@ describe TopologicalInventory::Orchestrator::Worker do
     expect(RestClient).to receive(:get).with(url_3).and_return(response_3)
 
     expect { |b| instance.send(:each_resource, url_1, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+  end
+
+  describe "#api_base_url (private)" do
+    let(:url) { subject.send(:api_base_url) }
+
+    it "returns a sane value" do
+      expect(url).to eq("http://example.com:8080/v0.1")
+    end
+
+    context "with APP_NAME set" do
+      around do |e|
+        ENV["APP_NAME"] = "topological-inventory"
+        e.run
+        ENV.delete("APP_NAME")
+        ENV.delete("PATH_PREFIX")
+      end
+
+      it "includes the APP_NAME" do
+        expect(url).to eq("http://example.com:8080/topological-inventory/v0.1")
+      end
+
+      it "uses the PATH_PREFIX with a leading slash" do
+        ENV["PATH_PREFIX"] = "/this/is/a/path"
+        expect(url).to eq("http://example.com:8080/this/is/a/path/topological-inventory/v0.1")
+      end
+
+      it "uses the PATH_PREFIX without a leading slash" do
+        ENV["PATH_PREFIX"] = "also/a/path"
+        expect(url).to eq("http://example.com:8080/also/a/path/topological-inventory/v0.1")
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows us to just pass the same vars that we are already giving
to the other services (PATH_PREFIX and APP_NAME).

Additionally we encode the api version in the source rather than
passing it as a part of a path environment variable.

If we were to pass it in, we run the risk of the code expecting
one version, but the API endpoint providing a different one. This
way, we will always be in sync.