### PR TITLE
Add the image trigger and alter image handling

### DIFF
--- a/config/collector_definitions.yaml
+++ b/config/collector_definitions.yaml
@@ -1,7 +1,8 @@
 # Layout of this file
 # <source_type>:
+#   image_namespace: <namespace> -- optional
 #   image: <image_ref>
 
 ---
 openshift:
-  image: "buildfactory/topological-inventory-ci/topological-inventory-openshift:latest"
+  image: "topological-inventory-openshift:latest"

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -81,7 +81,7 @@ module TopologicalInventory
           value = {
             "endpoint_host"   => endpoint["host"],
             "endpoint_path"   => endpoint["path"],
-            "endpoint_port"   => endpoint["port"],
+            "endpoint_port"   => endpoint["port"].to_s,
             "endpoint_scheme" => endpoint["scheme"],
             "image"           => collector_definition["image"],
             "source_id"       => source["id"],

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -84,6 +84,7 @@ module TopologicalInventory
             "endpoint_port"   => endpoint["port"].to_s,
             "endpoint_scheme" => endpoint["scheme"],
             "image"           => collector_definition["image"],
+            "image_namespace" => collector_definition["image_namespace"] || ENV["IMAGE_NAMESPACE"],
             "source_id"       => source["id"],
             "source_uid"      => source["uid"],
             "secret"          => {
@@ -144,13 +145,12 @@ module TopologicalInventory
       def create_openshift_objects_for_source(digest, source)
         logger.info("Creating objects for source #{source["source_id"]} with digest #{digest}")
         object_manager.create_secret(collector_deployment_secret_name_for_source(source), source["secret"])
-        object_manager.create_deployment_config(collector_deployment_name_for_source(source)) do |d|
+        object_manager.create_deployment_config(collector_deployment_name_for_source(source), source["image_namespace"], source["image"]) do |d|
           d[:metadata][:labels]["topological-inventory/collector_digest"] = digest
           d[:metadata][:labels]["topological-inventory/collector"] = "true"
           d[:spec][:replicas] = 1
           container = d[:spec][:template][:spec][:containers].first
           container[:env] = collector_container_environment(source)
-          container[:image] = source["image"]
         end
       end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -89,10 +89,10 @@ describe TopologicalInventory::Orchestrator::Worker do
       instance.send(:collectors_from_database, db)
 
       expect(db).to eq(
-        "f3105d3cdbfcf1c7eb722303a1739955a76b363e" => {
+        "d40a4b2ff60d57a58e4144f5f5da9fd8ab30c141" => {
           "endpoint_host"   => "example.com",
           "endpoint_path"   => "/api",
-          "endpoint_port"   => 8443,
+          "endpoint_port"   => "8443",
           "endpoint_scheme" => "https",
           "image"           => "buildfactory/topological-inventory-ci/topological-inventory-openshift:latest",
           "source_id"       => "2",

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -2,11 +2,13 @@ describe TopologicalInventory::Orchestrator::Worker do
   around do |e|
     ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"] = "example.com"
     ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"] = "8080"
+    ENV["IMAGE_NAMESPACE"] = "buildfactory"
 
     e.run
 
     ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST")
     ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_PORT")
+    ENV.delete("IMAGE_NAMESPACE")
   end
 
   context "#collectors_from_database" do
@@ -89,12 +91,13 @@ describe TopologicalInventory::Orchestrator::Worker do
       instance.send(:collectors_from_database, db)
 
       expect(db).to eq(
-        "d40a4b2ff60d57a58e4144f5f5da9fd8ab30c141" => {
+        "09ff859d6a98e23d69968d1419bf8b25b910d3ee" => {
           "endpoint_host"   => "example.com",
           "endpoint_path"   => "/api",
           "endpoint_port"   => "8443",
           "endpoint_scheme" => "https",
-          "image"           => "buildfactory/topological-inventory-ci/topological-inventory-openshift:latest",
+          "image"           => "topological-inventory-openshift:latest",
+          "image_namespace" => "buildfactory",
           "source_id"       => "2",
           "source_uid"      => "31b5338b-685d-4056-ba39-d00b4d7f19cc",
           "secret"          => {


### PR DESCRIPTION
This PR alters how the image for a collector is specified. Instead of listing out the fully qualified image, we now can specify the org/namespace of the image separately and default that to the `IMAGE_NAMESPACE` environment variable.

This is provided to most templates at deploy time and can be used here as well. The assumption is that the collector images will live in the same namespace as the orchestrator image. If that is not the case, the image namespace can be specified separately in the collector definitions file.

Additionally this PR fixes a small issue by calling `.to_s` on the port value in the collector deployment config.