### PR TITLE
Refactor some orchestrator worker methods

### DIFF
--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -49,7 +49,7 @@ module TopologicalInventory
 
       def make_openshift_match_database
         hash = {}
-        expected = collectors_from_database(hash)
+        expected = collectors_from_sources_api(hash)
         current  = collectors_from_openshift
 
         logger.info("Checking...")
@@ -75,7 +75,7 @@ module TopologicalInventory
         end
       end
 
-      def collectors_from_database(hash)
+      def collectors_from_sources_api(hash)
         each_source.collect do |source, endpoint, authentication, collector_definition|
           auth = authentication_with_password(authentication["id"])
           value = {

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -11,7 +11,7 @@ describe TopologicalInventory::Orchestrator::Worker do
     ENV.delete("IMAGE_NAMESPACE")
   end
 
-  context "#collectors_from_database" do
+  context "#collectors_from_sources_api" do
     let(:source_types_response) do
       <<~EOJ
         {
@@ -97,7 +97,7 @@ describe TopologicalInventory::Orchestrator::Worker do
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password")
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password")
 
-      instance.send(:collectors_from_database, db)
+      instance.send(:collectors_from_sources_api, db)
 
       expect(db).to eq(
         "09ff859d6a98e23d69968d1419bf8b25b910d3ee" => {

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -81,7 +81,6 @@ describe TopologicalInventory::Orchestrator::Worker do
     end
 
     it "generates the expected hash" do
-      db = {}
       instance = described_class.new
 
       expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types").and_return(source_types_response)
@@ -97,9 +96,9 @@ describe TopologicalInventory::Orchestrator::Worker do
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password")
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password")
 
-      instance.send(:collectors_from_sources_api, db)
+      collector_hash = instance.send(:collectors_from_sources_api)
 
-      expect(db).to eq(
+      expect(collector_hash).to eq(
         "09ff859d6a98e23d69968d1419bf8b25b910d3ee" => {
           "endpoint_host"   => "example.com",
           "endpoint_path"   => "/api",


### PR DESCRIPTION
This PR is just a refactoring for my sanity as I'm editing this code.

In particular it renames a few methods to better reflect what they're actually doing and removes an instance where we were editing a passed hash parameter.