### PR TITLE
Deal with tenancy 😎

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.1"
+gem "more_core_extensions", "~>3.7.0"
 gem "rest-client", "~>2.0"
 
 group :test do

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -107,8 +107,12 @@ module TopologicalInventory
       def each_resource(url, &block)
         return if url.nil?
         response = get_and_parse(url)
-        response["data"].each { |i| yield i }
-        each_resource(response["links"]["next"], &block)
+        paging = response.is_a?(Hash)
+
+        resources = paging ? response["data"] : response
+        resources.each { |i| yield i }
+
+        each_resource(response["links"]["next"], &block) if paging
       end
 
       def get_and_parse(url)

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -2,6 +2,7 @@ require "base64"
 require "json"
 require "manageiq-loggers"
 require "manageiq-password"
+require "more_core_extensions/core_ext/hash"
 require "rest-client"
 require "yaml"
 
@@ -122,7 +123,7 @@ module TopologicalInventory
         resources = paging ? response["data"] : response
         resources.each { |i| yield i }
 
-        each_resource(response["links"]["next"], tenant_account, &block) if paging
+        each_resource(response.fetch_path("links", "next"), tenant_account, &block) if paging
       end
 
       def get_and_parse(url, tenant_account = ORCHESTRATOR_TENANT)

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -100,6 +100,13 @@ module TopologicalInventory
         hash
       end
 
+      def internal_url_for(path, query = nil)
+        URI.parse(api_base_url).tap do |uri|
+          uri.path = File.join("/internal/v0.0/", path)
+          uri.query = query if query
+        end.to_s
+      end
+
       def url_for(path)
         File.join(api_base_url, path)
       end
@@ -122,11 +129,7 @@ module TopologicalInventory
 
       # HACK for Authentications
       def authentication_with_password(id)
-        url = URI.parse(api_base_url).tap do |uri|
-          uri.path = "/internal/v0.0/authentications/#{id}"
-          uri.query = "expose_encrypted_attribute[]=password"
-        end.to_s
-        get_and_parse(url.to_s)
+        get_and_parse(internal_url_for("/authentications/#{id}", "expose_encrypted_attribute[]=password"))
       end
 
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,4 +1,27 @@
 describe TopologicalInventory::Orchestrator::Worker do
+  let(:tenants_response) do
+    <<~EOJ
+      [
+        {
+          "id": "1",
+          "external_tenant": "#{user_tenant_account}"
+        }
+      ]
+    EOJ
+  end
+
+  let(:orchestrator_tenant_header) do
+    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6InN5c3RlbV9vcmNoZXN0\ncmF0b3IifX0="}
+  end
+
+  let(:user_tenant_account) { "12345" }
+
+  let(:user_tenant_header) do
+    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1In19"}
+  end
+
+  before { allow(RestClient).to receive(:get).with("http://example.com:8080/internal/v0.0/tenants", orchestrator_tenant_header).and_return(tenants_response) }
+
   around do |e|
     ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"] = "example.com"
     ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"] = "8080"
@@ -83,18 +106,18 @@ describe TopologicalInventory::Orchestrator::Worker do
     it "generates the expected hash" do
       instance = described_class.new
 
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types").and_return(source_types_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types/1/sources").and_return(source_types_1_sources_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/source_types/2/sources").and_return(source_types_2_sources_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/sources/1/endpoints").and_return(sources_1_endpoints_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/sources/2/endpoints").and_return(sources_2_endpoints_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=1").and_return(endpoints_1_authentications_response)
-      expect(RestClient).to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/1?expose_encrypted_attribute[]=password").and_return({"username" => "USER", "password" => "PASS"}.to_json)
+      stub_rest_get("http://example.com:8080/v0.1/source_types", user_tenant_header, source_types_response)
+      stub_rest_get("http://example.com:8080/v0.1/source_types/1/sources", user_tenant_header, source_types_1_sources_response)
+      stub_rest_get("http://example.com:8080/v0.1/source_types/2/sources", user_tenant_header, source_types_2_sources_response)
+      stub_rest_get("http://example.com:8080/v0.1/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
+      stub_rest_get("http://example.com:8080/v0.1/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
+      stub_rest_get("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=1", user_tenant_header, endpoints_1_authentications_response)
+      stub_rest_get("http://example.com:8080/internal/v0.0/authentications/1?expose_encrypted_attribute[]=password", orchestrator_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
 
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=8")
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=9")
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password")
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password")
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=8", any_args)
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=9", any_args)
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
 
       collector_hash = instance.send(:collectors_from_sources_api)
 
@@ -127,21 +150,29 @@ describe TopologicalInventory::Orchestrator::Worker do
     end
   end
 
-  it "#each_resource" do
-    instance = described_class.new
+  describe "#each_resource" do
+    it "works with paginated responses" do
+      url_1 = "http://example.com:8080/1"
+      url_2 = "http://example.com:8080/2"
+      url_3 = "http://example.com:8080/3"
+      response_1 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_2, "prev" => nil}, "data" => [1, 2, 3]}.to_json
+      response_2 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_3, "prev" => url_1}, "data" => [4, 5, 6]}.to_json
+      response_3 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => nil, "prev" => url_2}, "data" => [7, 8]}.to_json
 
-    url_1 = "http://example.com:8080/1"
-    url_2 = "http://example.com:8080/2"
-    url_3 = "http://example.com:8080/3"
-    response_1 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_2, "prev" => nil}, "data" => [1, 2, 3]}.to_json
-    response_2 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => url_3, "prev" => url_1}, "data" => [4, 5, 6]}.to_json
-    response_3 = {"meta" => {}, "links" => {"first" => url_1, "last" => url_3, "next" => nil, "prev" => url_2}, "data" => [7, 8]}.to_json
+      stub_rest_get(url_1, user_tenant_header, response_1)
+      stub_rest_get(url_2, user_tenant_header, response_2)
+      stub_rest_get(url_3, user_tenant_header, response_3)
 
-    expect(RestClient).to receive(:get).with(url_1).and_return(response_1)
-    expect(RestClient).to receive(:get).with(url_2).and_return(response_2)
-    expect(RestClient).to receive(:get).with(url_3).and_return(response_3)
+      expect { |b| described_class.new.send(:each_resource, url_1, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+    end
 
-    expect { |b| instance.send(:each_resource, url_1, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+    it "works with non-paginated responses" do
+      url = "http://example.com:8080/things"
+      response = [1, 2, 3, 4, 5, 6, 7, 8].to_json
+
+      stub_rest_get(url, user_tenant_header, response)
+      expect { |b| described_class.new.send(:each_resource, url, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+    end
   end
 
   describe "#api_base_url (private)" do
@@ -173,5 +204,9 @@ describe TopologicalInventory::Orchestrator::Worker do
         expect(url).to eq("http://example.com:8080/also/a/path/topological-inventory/v0.1")
       end
     end
+  end
+
+  def stub_rest_get(path, tenant_header, response)
+    expect(RestClient).to receive(:get).with(path, tenant_header).and_return(response)
   end
 end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -117,6 +117,16 @@ describe TopologicalInventory::Orchestrator::Worker do
     end
   end
 
+  describe "#internal_url_for" do
+    it "replaces the path with /internal/v0.0/<path>" do
+      expect(described_class.new.send(:internal_url_for, "the/best/path")).to eq("http://example.com:8080/internal/v0.0/the/best/path")
+    end
+
+    it "adds the passed query" do
+      expect(described_class.new.send(:internal_url_for, "the/path", "query=param")).to eq("http://example.com:8080/internal/v0.0/the/path?query=param")
+    end
+  end
+
   it "#each_resource" do
     instance = described_class.new
 


### PR DESCRIPTION
This PR makes the orchestrator pass a tenant header with each of its requests.

To query for sources we have to first use the internal API to query for tenants. For this call (and all others to the internal API) we use a special tenant identifier which won't collide with existing users. After we have the list of tenants we can then query for sources and their dependent objects tenant-by-tenant.

Also of note here, this PR changes the `#each_resource` method so that it can deal with both paginated and non-paginated responses as the internal API doesn't use paginated responses.

This will resolve https://projects.engineering.redhat.com/browse/TPINVTRY-282