### PR TITLE
Use the sources service for the orchestrator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.1"
 gem "more_core_extensions", "~>3.7.0"
+gem "optimist"
 gem "rest-client", "~>2.0"
 
 group :test do

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -6,27 +6,13 @@ require "bundler/setup"
 
 $:.push File.expand_path("../../lib", __FILE__)
 
-def default_sources_url
-  return if ENV.values_at("SOURCES_SCHEME", "SOURCES_HOST", "SOURCES_PORT").any?(&:nil?)
-  URI::Generic.build(
-    :scheme => ENV["SOURCES_SCHEME"], :host => ENV["SOURCES_HOST"], :port => ENV["SOURCES_PORT"]
-  ).to_s
-end
-
-def default_topology_url
-  return if ENV.values_at("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST", "TOPOLOGICAL_INVENTORY_API_SERVICE_PORT").any?(&:nil?)
-  URI::Generic.build(
-    :scheme => "http", :host => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"], :port => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"]
-  ).to_s
-end
-
 def parse_args
   require 'optimist'
   opts = Optimist.options do
-    opt :sources_url, "TODO", :type => :string,
-        :default => default_sources_url, :required => default_sources_url.nil?
-    opt :topology_url, "TODO", :type => :string,
-        :default => default_topology_url, :required => default_topology_url.nil?
+    opt :sources_api, "TODO", :type => :string,
+        :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
+    opt :topology_api, "TODO", :type => :string,
+        :default => ENV["TOPOLOGICAL_INVENTORY_API"], :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?
   end
 
   opts
@@ -35,7 +21,5 @@ end
 require "topological_inventory-orchestrator"
 
 args = parse_args
-w = TopologicalInventory::Orchestrator::Worker.new(
-  :sources_url  => args[:sources_url],
-  :topology_url => args[:topology_url])
+w = TopologicalInventory::Orchestrator::Worker.new(sources_api: args[:sources_api], topology_api: args[:topology_api])
 w.run

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -6,7 +6,36 @@ require "bundler/setup"
 
 $:.push File.expand_path("../../lib", __FILE__)
 
+def default_sources_url
+  return if ENV.values_at("SOURCES_SCHEME", "SOURCES_HOST", "SOURCES_PORT").any?(&:nil?)
+  URI::Generic.build(
+    :scheme => ENV["SOURCES_SCHEME"], :host => ENV["SOURCES_HOST"], :port => ENV["SOURCES_PORT"]
+  ).to_s
+end
+
+def default_topology_url
+  return if ENV.values_at("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST", "TOPOLOGICAL_INVENTORY_API_SERVICE_PORT").any?(&:nil?)
+  URI::Generic.build(
+    :scheme => "http", :host => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"], :port => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"]
+  ).to_s
+end
+
+def parse_args
+  require 'optimist'
+  opts = Optimist.options do
+    opt :sources_url, "TODO", :type => :string,
+        :default => default_sources_url, :required => default_sources_url.nil?
+    opt :topology_url, "TODO", :type => :string,
+        :default => default_topology_url, :required => default_topology_url.nil?
+  end
+
+  opts
+end
+
 require "topological_inventory-orchestrator"
 
-w = TopologicalInventory::Orchestrator::Worker.new
+args = parse_args
+w = TopologicalInventory::Orchestrator::Worker.new(
+  :sources_url  => args[:sources_url],
+  :topology_url => args[:topology_url])
 w.run

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -9,9 +9,9 @@ $:.push File.expand_path("../../lib", __FILE__)
 def parse_args
   require 'optimist'
   opts = Optimist.options do
-    opt :sources_api, "TODO", :type => :string,
+    opt :sources_api, "URL to the sources service, e.g. http://localhost:3000/api/v1.0", :type => :string,
         :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
-    opt :topology_api, "TODO", :type => :string,
+    opt :topology_api, "URL to the topological inventory service, e.g. http://localhost:4000/api/v0.1", :type => :string,
         :default => ENV["TOPOLOGICAL_INVENTORY_API"], :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?
   end
 

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -38,8 +38,8 @@ module TopologicalInventory
           require "uri"
 
           URI::HTTP.build(
-            :host => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"],
-            :port => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"],
+            :host => ENV["SOURCES_HOST"],
+            :port => ENV["SOURCES_PORT"],
             :path => path
           ).to_s
         end
@@ -106,7 +106,7 @@ module TopologicalInventory
 
       def internal_url_for(path, query = nil)
         URI.parse(api_base_url).tap do |uri|
-          uri.path = File.join("/internal/v0.0/", path)
+          uri.path = File.join("/internal/v0.1/", path)
           uri.query = query if query
         end.to_s
       end

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -61,8 +61,8 @@ module TopologicalInventory
         each_resource(sources_api_url_for("source_types")) { |source_type| source_types_by_id[source_type["id"]] = source_type }
 
         each_tenant do |tenant|
-          each_resource(topology_api_url_for("sources"), tenant) do |source_stub|
-            source      = get_and_parse(sources_api_url_for("sources/#{source_stub["id"]}"), tenant)
+          each_resource(topology_api_url_for("sources"), tenant) do |topology_source|
+            source      = get_and_parse(sources_api_url_for("sources/#{topology_source["id"]}"), tenant)
             source_type = source_types_by_id[source["source_type_id"]]
 
             next unless collector_definition = collector_definitions[source_type["name"]]

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -11,14 +11,18 @@ require "topological_inventory/orchestrator/object_manager"
 module TopologicalInventory
   module Orchestrator
     class Worker
-      API_VERSION = "v0.1".freeze
+      TOPOLOGY_API_VERSION = "v0.1".freeze
+      SOURCES_API_VERSION = "v1.0".freeze
       ORCHESTRATOR_TENANT = "system_orchestrator".freeze
 
-      attr_reader :logger
+      attr_reader :logger, :sources_url, :topology_url
 
-      def initialize(collector_definitions_file = ENV["COLLECTOR_DEFINITIONS_FILE"])
+      def initialize(sources_url:, topology_url:, collector_definitions_file: ENV["COLLECTOR_DEFINITIONS_FILE"])
         @collector_definitions_file = collector_definitions_file || TopologicalInventory::Orchestrator.root.join("config/collector_definitions.yaml")
-        @logger = ManageIQ::Loggers::Container.new
+
+        @logger       = ManageIQ::Loggers::Container.new
+        @sources_url  = sources_url
+        @topology_url = topology_url
       end
 
       def run
@@ -30,20 +34,6 @@ module TopologicalInventory
       end
 
       private
-
-      def api_base_url
-        @api_base_url ||= begin
-          path = File.join("/", ENV["PATH_PREFIX"].to_s, ENV["APP_NAME"].to_s, API_VERSION)
-
-          require "uri"
-
-          URI::HTTP.build(
-            :host => ENV["SOURCES_HOST"],
-            :port => ENV["SOURCES_PORT"],
-            :path => path
-          ).to_s
-        end
-      end
 
       def digest(object)
         require 'digest'
@@ -67,16 +57,21 @@ module TopologicalInventory
 
       ### API STUFF
       def each_source
+        source_types_by_id = {}
+        each_resource(sources_api_url_for("source_types")) { |source_type| source_types_by_id[source_type["id"]] = source_type }
+
         each_tenant do |tenant|
-          each_resource(url_for("source_types"), tenant) do |source_type|
-            collector_definition = collector_definitions[source_type["name"]]
-            next if collector_definition.nil?
-            each_resource(url_for("source_types/#{source_type["id"]}/sources"), tenant) do |source|
-              next unless endpoint = get_and_parse(url_for("sources/#{source["id"]}/endpoints"), tenant)["data"].first
-              next unless authentication = get_and_parse(url_for("authentications?resource_type=Endpoint&resource_id=#{endpoint["id"]}"), tenant)["data"].first
-              auth = authentication_with_password(authentication["id"], tenant)
-              yield source, endpoint, auth, collector_definition
-            end
+          each_resource(topology_api_url_for("sources"), tenant) do |source_stub|
+            source      = get_and_parse(sources_api_url_for("sources/#{source_stub["id"]}"), tenant)
+            source_type = source_types_by_id[source["source_type_id"]]
+
+            next unless collector_definition = collector_definitions[source_type["name"]]
+
+            next unless endpoint       = get_and_parse(sources_api_url_for("sources/#{source["id"]}/endpoints"), tenant)["data"].first
+            next unless authentication = get_and_parse(sources_api_url_for("endpoints/#{endpoint["id"]}/authentications"), tenant)["data"].first
+
+            auth = authentication_with_password(authentication["id"], tenant)
+            yield source, endpoint, auth, collector_definition
           end
         end
       end
@@ -104,15 +99,20 @@ module TopologicalInventory
         hash
       end
 
-      def internal_url_for(path, query = nil)
-        URI.parse(api_base_url).tap do |uri|
-          uri.path = File.join("/internal/v0.1/", path)
-          uri.query = query if query
-        end.to_s
+      def sources_api_url_for(path)
+        File.join(sources_url, ENV["PATH_PREFIX"].to_s, ENV["APP_NAME"].to_s, SOURCES_API_VERSION, path)
       end
 
-      def url_for(path)
-        File.join(api_base_url, path)
+      def sources_internal_url_for(path)
+        File.join(sources_url, "internal", "v1.0", path)
+      end
+
+      def topology_api_url_for(path)
+        File.join(topology_url, ENV["PATH_PREFIX"].to_s, ENV["APP_NAME"].to_s, TOPOLOGY_API_VERSION, path)
+      end
+
+      def topology_internal_url_for(path)
+        File.join(topology_url, "internal", "v0.0", path)
       end
 
       def each_resource(url, tenant_account = ORCHESTRATOR_TENANT, &block)
@@ -138,12 +138,12 @@ module TopologicalInventory
       end
 
       def each_tenant
-        each_resource(internal_url_for("tenants")) { |tenant| yield tenant["external_tenant"] }
+        each_resource(topology_internal_url_for("tenants")) { |tenant| yield tenant["external_tenant"] }
       end
 
       # HACK for Authentications
       def authentication_with_password(id, tenant_account)
-        get_and_parse(internal_url_for("/authentications/#{id}", "expose_encrypted_attribute[]=password"), tenant_account)
+        get_and_parse(sources_internal_url_for("/authentications/#{id}?expose_encrypted_attribute[]=password"), tenant_account)
       end
 
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -28,10 +28,10 @@ describe TopologicalInventory::Orchestrator::Worker do
     ENV.delete("IMAGE_NAMESPACE")
   end
 
-  subject { described_class.new(sources_url: sources_url, topology_url: topology_url) }
+  subject { described_class.new(sources_api: sources_api, topology_api: topology_api) }
 
-  let(:sources_url)  { "http://example.com:8080" }
-  let(:topology_url) { "http://example.com:8080" }
+  let(:sources_api)  { "http://example.com:8080/api/sources/v1.0" }
+  let(:topology_api) { "http://example.com:8080/api/topological-inventory/v0.1" }
 
   context "#collectors_from_sources_api" do
     let(:source_types_response) do
@@ -167,37 +167,6 @@ describe TopologicalInventory::Orchestrator::Worker do
 
       stub_rest_get(url, user_tenant_header, response)
       expect { |b| subject.send(:each_resource, url, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
-    end
-  end
-
-  describe "#api_base_url (private)" do
-    let(:url) { subject.send(:topology_api_url_for, "sources") }
-
-    it "returns a sane value" do
-      expect(url).to eq("http://example.com:8080/v0.1/sources")
-    end
-
-    context "with APP_NAME set" do
-      around do |e|
-        ENV["APP_NAME"] = "topological-inventory"
-        e.run
-        ENV.delete("APP_NAME")
-        ENV.delete("PATH_PREFIX")
-      end
-
-      it "includes the APP_NAME" do
-        expect(url).to eq("http://example.com:8080/topological-inventory/v0.1/sources")
-      end
-
-      it "uses the PATH_PREFIX with a leading slash" do
-        ENV["PATH_PREFIX"] = "/this/is/a/path"
-        expect(url).to eq("http://example.com:8080/this/is/a/path/topological-inventory/v0.1/sources")
-      end
-
-      it "uses the PATH_PREFIX without a leading slash" do
-        ENV["PATH_PREFIX"] = "also/a/path"
-        expect(url).to eq("http://example.com:8080/also/a/path/topological-inventory/v0.1/sources")
-      end
     end
   end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -20,17 +20,17 @@ describe TopologicalInventory::Orchestrator::Worker do
     {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1In19"}
   end
 
-  before { allow(RestClient).to receive(:get).with("http://example.com:8080/internal/v0.0/tenants", orchestrator_tenant_header).and_return(tenants_response) }
+  before { allow(RestClient).to receive(:get).with("http://example.com:8080/internal/v0.1/tenants", orchestrator_tenant_header).and_return(tenants_response) }
 
   around do |e|
-    ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"] = "example.com"
-    ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"] = "8080"
+    ENV["SOURCES_HOST"] = "example.com"
+    ENV["SOURCES_PORT"] = "8080"
     ENV["IMAGE_NAMESPACE"] = "buildfactory"
 
     e.run
 
-    ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST")
-    ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_PORT")
+    ENV.delete("SOURCES_HOST")
+    ENV.delete("SOURCES_PORT")
     ENV.delete("IMAGE_NAMESPACE")
   end
 
@@ -112,12 +112,12 @@ describe TopologicalInventory::Orchestrator::Worker do
       stub_rest_get("http://example.com:8080/v0.1/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
       stub_rest_get("http://example.com:8080/v0.1/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
       stub_rest_get("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=1", user_tenant_header, endpoints_1_authentications_response)
-      stub_rest_get("http://example.com:8080/internal/v0.0/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
+      stub_rest_get("http://example.com:8080/internal/v0.1/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
 
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=8", any_args)
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/v0.1/authentications?resource_type=Endpoint&resource_id=9", any_args)
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.1/authentications/8?expose_encrypted_attribute[]=password", any_args)
+      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v0.1/authentications/9?expose_encrypted_attribute[]=password", any_args)
 
       collector_hash = instance.send(:collectors_from_sources_api)
 
@@ -141,12 +141,12 @@ describe TopologicalInventory::Orchestrator::Worker do
   end
 
   describe "#internal_url_for" do
-    it "replaces the path with /internal/v0.0/<path>" do
-      expect(described_class.new.send(:internal_url_for, "the/best/path")).to eq("http://example.com:8080/internal/v0.0/the/best/path")
+    it "replaces the path with /internal/v0.1/<path>" do
+      expect(described_class.new.send(:internal_url_for, "the/best/path")).to eq("http://example.com:8080/internal/v0.1/the/best/path")
     end
 
     it "adds the passed query" do
-      expect(described_class.new.send(:internal_url_for, "the/path", "query=param")).to eq("http://example.com:8080/internal/v0.0/the/path?query=param")
+      expect(described_class.new.send(:internal_url_for, "the/path", "query=param")).to eq("http://example.com:8080/internal/v0.1/the/path?query=param")
     end
   end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -28,8 +28,8 @@ describe TopologicalInventory::Orchestrator::Worker do
 
   subject { described_class.new(sources_api: sources_api, topology_api: topology_api) }
 
-  let(:sources_api)  { "http://example.com:8080/api/sources/v1.0" }
-  let(:topology_api) { "http://example.com:8080/api/topological-inventory/v0.1" }
+  let(:sources_api)  { "http://sources.local:8080/api/sources/v1.0" }
+  let(:topology_api) { "http://topology.local:8080/api/topological-inventory/v0.1" }
 
   context "#collectors_from_sources_api" do
     let(:source_types_response) do
@@ -108,20 +108,20 @@ describe TopologicalInventory::Orchestrator::Worker do
     end
 
     it "generates the expected hash" do
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/source_types", orchestrator_tenant_header, source_types_response)
-      stub_rest_get("http://example.com:8080/internal/v0.0/tenants", orchestrator_tenant_header, tenants_response)
-      stub_rest_get("http://example.com:8080/api/topological-inventory/v0.1/sources", user_tenant_header, topology_sources_response)
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/sources/1", user_tenant_header, sources_1_response)
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/sources/2", user_tenant_header, sources_2_response)
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
-      stub_rest_get("http://example.com:8080/api/sources/v1.0/endpoints/1/authentications", user_tenant_header, endpoints_1_authentications_response)
-      stub_rest_get("http://example.com:8080/internal/v1.0/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
+      stub_rest_get("#{sources_api}/source_types", orchestrator_tenant_header, source_types_response)
+      stub_rest_get("http://topology.local:8080/internal/v0.0/tenants", orchestrator_tenant_header, tenants_response)
+      stub_rest_get("#{topology_api}/sources", user_tenant_header, topology_sources_response)
+      stub_rest_get("#{sources_api}/sources/1", user_tenant_header, sources_1_response)
+      stub_rest_get("#{sources_api}/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
+      stub_rest_get("#{sources_api}/sources/2", user_tenant_header, sources_2_response)
+      stub_rest_get("#{sources_api}/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
+      stub_rest_get("#{sources_api}/endpoints/1/authentications", user_tenant_header, endpoints_1_authentications_response)
+      stub_rest_get("http://sources.local:8080/internal/v1.0/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
 
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/api/sources/v1.0/endpoints/8/authentications", any_args)
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/api/sources/v1.0/endpoints/9/authentications", any_args)
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v1.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
-      expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v1.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
+      expect(RestClient).not_to receive(:get).with("#{sources_api}/endpoints/8/authentications", any_args)
+      expect(RestClient).not_to receive(:get).with("#{sources_api}/endpoints/9/authentications", any_args)
+      expect(RestClient).not_to receive(:get).with("http://sources.local:8080/internal/v1.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
+      expect(RestClient).not_to receive(:get).with("http://sources.local:8080/internal/v1.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
 
       collector_hash = subject.send(:collectors_from_sources_api)
 
@@ -146,7 +146,7 @@ describe TopologicalInventory::Orchestrator::Worker do
 
   describe "#internal_url_for" do
     it "replaces the path with /internal/v0.1/<path>" do
-      expect(subject.send(:topology_internal_url_for, "the/best/path")).to eq("http://example.com:8080/internal/v0.0/the/best/path")
+      expect(subject.send(:topology_internal_url_for, "the/best/path")).to eq("http://topology.local:8080/internal/v0.0/the/best/path")
     end
   end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -108,8 +108,6 @@ describe TopologicalInventory::Orchestrator::Worker do
     end
 
     it "generates the expected hash" do
-      instance = subject
-
       stub_rest_get("http://example.com:8080/api/sources/v1.0/source_types", orchestrator_tenant_header, source_types_response)
       stub_rest_get("http://example.com:8080/internal/v0.0/tenants", orchestrator_tenant_header, tenants_response)
       stub_rest_get("http://example.com:8080/api/topological-inventory/v0.1/sources", user_tenant_header, topology_sources_response)
@@ -125,7 +123,7 @@ describe TopologicalInventory::Orchestrator::Worker do
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v1.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
       expect(RestClient).not_to receive(:get).with("http://example.com:8080/internal/v1.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
 
-      collector_hash = instance.send(:collectors_from_sources_api)
+      collector_hash = subject.send(:collectors_from_sources_api)
 
       expect(collector_hash).to eq(
         "09ff859d6a98e23d69968d1419bf8b25b910d3ee" => {


### PR DESCRIPTION
Update to use the sources service for getting source_types, sources,
endpoints, and authentications for starting collectors.

Depends on: https://github.com/RedHatInsights/e2e-deploy/pull/241