### PR TITLE
Lower the cpu request and limit for collector deployment configs

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -107,11 +107,11 @@ module TopologicalInventory
                   :image         => "#{image_namespace}/#{image}",
                   :resources     => {
                     :limits   => {
-                      :cpu    => "200m",
+                      :cpu    => "50m",
                       :memory => "400Mi"
                     },
                     :requests => {
-                      :cpu    => "100m",
+                      :cpu    => "20m",
                       :memory => "200Mi"
                     }
                   }


### PR DESCRIPTION
We can now request under 100m for CPU as the Limit Ranges in our
namespaces were updated.

@agrare @Ladas I chose these numbers based on what I can see in the CI env. Do you think we'll get much higher than this?

cc @gtanzillo 