### PR TITLE
Add metrics using prometheus exporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.1"
 gem "more_core_extensions", "~>3.7.0"
 gem "optimist"
+gem "prometheus_exporter", "~> 0.4.5"
 gem "rest-client", "~>2.0"
 
 group :test do

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-Signal.trap("TERM") { exit }
-
 require "bundler/setup"
 
 $:.push File.expand_path("../../lib", __FILE__)
@@ -9,6 +7,7 @@ $:.push File.expand_path("../../lib", __FILE__)
 def parse_args
   require 'optimist'
   opts = Optimist.options do
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => 9394
     opt :sources_api, "URL to the sources service, e.g. http://localhost:3000/api/v1.0", :type => :string,
         :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
     opt :topology_api, "URL to the topological inventory service, e.g. http://localhost:4000/api/v0.1", :type => :string,
@@ -19,7 +18,16 @@ def parse_args
 end
 
 require "topological_inventory-orchestrator"
+require "topological_inventory/orchestrator/application_metrics"
 
 args = parse_args
+
+metrics = TopologicalInventory::Orchestrator::ApplicationMetrics.new(args[:metrics_port])
+
+Signal.trap("TERM") do
+  metrics.stop_server
+  exit
+end
+
 w = TopologicalInventory::Orchestrator::Worker.new(sources_api: args[:sources_api], topology_api: args[:topology_api])
 w.run

--- a/lib/topological_inventory/orchestrator/application_metrics.rb
+++ b/lib/topological_inventory/orchestrator/application_metrics.rb
@@ -1,0 +1,36 @@
+require "benchmark"
+require "prometheus_exporter"
+require "prometheus_exporter/server"
+require "prometheus_exporter/client"
+require 'prometheus_exporter/instrumentation'
+
+module TopologicalInventory
+  module Orchestrator
+    class ApplicationMetrics
+      def initialize(port = 9394)
+        return if port == 0
+
+        configure_server(port) 
+        configure_metrics
+      end
+
+      def stop_server
+        @server&.stop
+      end
+
+      private
+
+      def configure_server(port)
+        @server = PrometheusExporter::Server::WebServer.new(:port => port)
+        @server.start
+
+        PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(:collector => @server.collector)
+      end
+
+      def configure_metrics
+        PrometheusExporter::Instrumentation::Process.start
+        PrometheusExporter::Metric::Base.default_prefix = "topological_inventory_orchestrator_"
+      end
+    end
+  end
+end


### PR DESCRIPTION
For now this will just expose the built-in ruby metrics as there's
not much to monitor from the orchestrator

This will also disable metrics if the port is passed as 0. cc @agrare 