### PR TITLE
Multisource collectors support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "cloudwatchlogger", "~>0.2"
+gem "config", "~> 1.7.2"
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.4"
 gem "more_core_extensions", "~>3.7.0"

--- a/bin/topological_inventory-orchestrator
+++ b/bin/topological_inventory-orchestrator
@@ -14,6 +14,7 @@ def parse_args
         :default => ENV["SOURCES_API"], :required => ENV["SOURCES_API"].nil?
     opt :topology_api, "URL to the topological inventory service, e.g. http://localhost:4000/api/v0.1", :type => :string,
         :default => ENV["TOPOLOGICAL_INVENTORY_API"], :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?
+    opt :config, "Configuration YAML file name", :type => :string, :default => ENV["CONFIG"] || 'default'
   end
 
   opts
@@ -31,5 +32,5 @@ Signal.trap("TERM") do
   exit
 end
 
-w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api])
+w = TopologicalInventory::Orchestrator::Worker.new(:collector_image_tag => args[:collector_image_tag], :sources_api => args[:sources_api], :topology_api => args[:topology_api], :config_name => args[:config])
 w.run

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,5 @@
+collectors:
+  sources_per_collector:
+    amazon: 2
+    ansible-tower: 2
+    openshift: 2

--- a/lib/topological_inventory/orchestrator/api.rb
+++ b/lib/topological_inventory/orchestrator/api.rb
@@ -1,0 +1,135 @@
+module TopologicalInventory
+  module Orchestrator
+    class Api
+      attr_accessor :sources_api, :sources_internal_api, :topology_api, :topology_internal_api
+
+      def initialize(sources_api:, topology_api:)
+        self.sources_api = sources_api
+        self.sources_internal_api = URI.parse(sources_api).tap { |uri| uri.path = "/internal/v1.0" }.to_s
+
+        self.topology_api = topology_api
+        self.topology_internal_api = URI.parse(topology_api).tap { |uri| uri.path = "/internal/v1.0" }.to_s
+      end
+
+      def each_tenant
+        each_resource(topology_internal_url_for("tenants")) { |tenant| yield tenant["external_tenant"] }
+      end
+
+      def each_source_type
+        each_resource(sources_api_url_for("source_types")) { |source_type| yield source_type }
+      end
+
+      def each_source
+        each_tenant do |tenant|
+          # Query applications for the supported application_types, then later we can check if the source
+          # has any supported applications from this hash
+          applications_by_source_id = each_resource(supported_applications_url, tenant).group_by { |application| application["source_id"] }
+
+          each_resource(topology_api_url_for("sources"), tenant) do |topology_source|
+            source = get_and_parse(sources_api_url_for("sources", topology_source["id"].to_s), tenant)
+
+            if source.present?
+              applications_for_source = applications_by_source_id[source["id"]]
+              yield source, tenant if applications_for_source.present?
+            end
+          end
+        end
+      end
+
+      def each_application_type
+        each_resource(sources_api_url_for("application_types"))
+      end
+
+      def get_endpoint(source_id, tenant)
+        endpoints = get_and_parse(sources_api_url_for("sources", source_id, "endpoints"), tenant)
+        endpoints&.dig("data")&.first
+      end
+
+      def get_authentication(endpoint_id, tenant)
+        authentications = get_and_parse(sources_api_url_for("endpoints", endpoint_id, "authentications"), tenant)
+        authentications&.dig("data")&.first
+      end
+
+      def get_credentials(authentication_id, tenant)
+        get_and_parse(sources_internal_url_for("/authentications/#{authentication_id}?expose_encrypted_attribute[]=password"), tenant)
+      end
+
+      def update_topological_inventory_source_refresh_status(source, refresh_status)
+        RestClient.patch(
+          topology_internal_url_for("sources", source["id"]),
+          {:refresh_status => refresh_status}.to_json,
+          tenant_header(source["tenant"])
+        )
+      rescue RestClient::NotFound
+        logger.error("Failed to update 'refresh_status' on source #{source["id"]}")
+      end
+
+      private
+
+      def each_resource(url, tenant_account = Worker::ORCHESTRATOR_TENANT, &block)
+        return enum_for(:each_resource, url, tenant_account) unless block_given?
+        return if url.nil?
+
+        response = get_and_parse(url, tenant_account)
+        paging = response.kind_of?(Hash)
+
+        resources = paging ? response["data"] : response
+        resources&.each { |i| yield i }
+
+        return unless paging
+
+        next_page_link = response.fetch_path("links", "next")
+        return unless next_page_link
+
+        next_url = URI.parse(url).merge(next_page_link).to_s
+
+        each_resource(next_url, tenant_account, &block)
+      end
+
+      def sources_api_url_for(*path)
+        File.join(sources_api, *path)
+      end
+
+      def sources_internal_url_for(*path)
+        File.join(sources_internal_api, *path)
+      end
+
+      def topology_api_url_for(*path)
+        File.join(topology_api, *path)
+      end
+
+      def topology_internal_url_for(*path)
+        File.join(topology_internal_api, *path)
+      end
+
+      def get_and_parse(url, tenant_account = Worker::ORCHESTRATOR_TENANT)
+        JSON.parse(
+          RestClient.get(url, tenant_header(tenant_account))
+        )
+      rescue RestClient::NotFound
+        nil
+      end
+
+      def tenant_header(tenant_account)
+        {"x-rh-identity" => Base64.strict_encode64({"identity" => {"account_number" => tenant_account}}.to_json)}
+      end
+
+      # Set of ids for supported applications
+      def supported_application_type_ids
+        topology_app_name = "/insights/platform/topological-inventory"
+
+        each_application_type.select do |application_type|
+          application_type["name"] == topology_app_name || application_type["dependent_applications"]&.include?(topology_app_name)
+        end.map do |application_type|
+          application_type["id"]
+        end
+      end
+
+      # URL to get a list of applications for supported application types
+      def supported_applications_url
+        query = URI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq][]=#{id}" }.join("&"))
+        sources_api_url_for("applications?#{query}")
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/api_object.rb
+++ b/lib/topological_inventory/orchestrator/api_object.rb
@@ -1,0 +1,15 @@
+module TopologicalInventory
+  module Orchestrator
+    class ApiObject
+      include Logging
+
+      delegate :[], :to => :attributes
+
+      attr_accessor :attributes
+
+      def initialize(attributes)
+        self.attributes = attributes
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/config_map.rb
+++ b/lib/topological_inventory/orchestrator/config_map.rb
@@ -1,0 +1,263 @@
+require "yaml"
+require "topological_inventory/orchestrator/openshift_object"
+
+module TopologicalInventory
+  module Orchestrator
+    # The ConfigMap is identified by label LABEL_COMMON (not unique)
+    # And by UUID, which is unique (data.uid)
+    # This UUID is also written to associated deployment_config and secret
+    class ConfigMap < OpenshiftObject
+      LABEL_COMMON = "tp-inventory/collectors-config-map".freeze
+      LABEL_UNIQUE = "tp-inventory/config-uid".freeze
+      LABEL_SOURCE_TYPE = "tp-inventory/source-type".freeze
+
+      attr_accessor :deployment_config, :secret, :source_type, :sources
+
+      def to_s
+        str = "#{uid} [#{sources.count} sources]"
+        str += " (#{source_type})" if source_type.present?
+        str
+      end
+
+      # Found new Source and no available ConfigMap + DC + Secret
+      def self.deploy_new(object_manager, source)
+        config_map = self.new(object_manager, nil)
+        source.config_map = config_map
+        config_map.init_from_source!(source)
+        config_map
+      end
+
+      def initialize(object_manager, openshift_object)
+        super(object_manager, openshift_object)
+
+        self.source_type = nil
+        self.sources = []
+      end
+
+      # Creates new ConfigMap, DeploymentConfig, Secret in **openshift**
+      # @param source [Source]
+      def init_from_source!(source)
+        self.source_type = source.source_type
+        self.sources << source
+
+        create_in_openshift(source)
+      end
+
+      # Connects ConfigMap's label and SourceType
+      # @param source_types [Array<SourceType>]
+      def assign_source_type!(source_types)
+        source_type_name = source_type_by_label
+
+        source_types.each do |st|
+          if st['name'] == source_type_name
+            self.source_type = st
+          end
+        end
+      end
+
+      # Pairs Sources(API) with ConfigMap (Source's digest with digests list loaded from ConfigMap)
+      #
+      # Either finds `Source(:from_sources_api => true)` in sources_by_digest (found on both sides, no change)
+      #  or creates marker for deleting `Source(:from_sources_api => false)` from ConfigMap
+      #
+      # @param [Hash<String,Source>] sources_by_digest<digest, Source(:from_sources_api => true)>
+      def associate_sources(sources_by_digest)
+        digests.each do |digest|
+          source = sources_by_digest[digest]
+          if source.nil?
+            # This source is not in API, will be deleted from openshift
+            source = Source.new({}, nil, source_type, nil, :from_sources_api => false)
+            source.digest = digest
+            sources_by_digest[digest] = source
+            logger.debug("Assoc Map (#{uid}) -> Source (digest #{digest}) not found")
+          else
+            logger.debug("Assoc Map (#{uid}) -> Source (digest #{digest}) found: #{source}")
+          end
+          source.config_map = self
+          sources << source
+        end
+        sources_by_digest
+      end
+
+      # Adds Source to this ConfigMap and Secret
+      # Collector's app reloads config map automatically
+      def add_source(source)
+        logger.info("Adding Source #{source} to ConfigMap #{self}")
+
+        raise "ConfigMap not available" unless available?(source)
+
+        if source.digest.present?
+          if !digests.include?(source.digest)
+            digests << source.digest
+            sources << source
+            update!
+            logger.info("[OK] Added Source #{source} to ConfigMap #{self}")
+          else
+            logger.warn("[WARN] Trying to add already added source #{source} to ConfigMap #{self}")
+          end
+        else
+          logger.warn("[WARN] Trying to add source #{source} without digest to ConfigMap #{self}")
+        end
+      end
+
+      # Remove Source from this ConfigMap and Secret
+      # If no sources in ConfigMap left, delete it, secret and DC (DeploymentConfig)
+      def remove_source(source)
+        logger.info("Removing Source #{source} from ConfigMap #{self}")
+
+        digests.delete(source.digest) if source.digest.present?
+        sources.delete(source)
+
+        if sources.size.zero?
+          delete_in_openshift
+        else
+          update!
+        end
+
+        logger.info("[OK] Removed Source #{source} from ConfigMap #{self}")
+      end
+
+      # Is config map available for source?
+      # True if free space in sources array and the same source type
+      def available?(source)
+        compatible?(source) && free_slot?
+      end
+
+      # Creating new ConfigMap in OpenShift (when no existing available)
+      # Also creates secret and deployment_config (connected by UID)
+      def create_in_openshift(source)
+        logger.info("Creating ConfigMap #{self} by Source #{source}")
+
+        object_manager.create_config_map(name) do |map|
+          map[:metadata][:labels][LABEL_COMMON] = "true"
+          map[:metadata][:labels][LABEL_SOURCE_TYPE] = source_type['name'] if source_type.present?
+          map[:metadata][:labels][LABEL_UNIQUE] = uid
+          map[:data][:uid] = uid
+          map[:data][:digests] = [source.digest].to_json
+          map[:data]["custom.yml"] = yaml_from_sources
+        end
+
+        logger.info("[OK] Created ConfigMap #{self}")
+
+        create_secret
+
+        create_deployment_config
+      end
+
+      def create_secret
+        self.secret = new_secret.tap do |s|
+          s.config_map = self
+        end
+        secret.create_in_openshift
+      end
+
+      def create_deployment_config
+        self.deployment_config = new_deployment_config.tap do |dc|
+          dc.config_map = self
+        end
+        deployment_config.create_in_openshift
+      end
+
+      def delete_in_openshift
+        deployment_config&.delete_in_openshift
+        secret&.delete_in_openshift
+
+        logger.info("Deleting ConfigMap #{self}")
+
+        object_manager.delete_config_map(name)
+
+        logger.info("[OK] Deleted ConfigMap #{self}")
+      end
+
+      def name
+        "tp-inventory-configmap-#{uid}"
+      end
+
+      # New ConfigMap is associated with random UUID
+      def uid
+        return @uid if @uid.present?
+
+        @uid = if @openshift_object.nil? # no openshift_object reloading here (cycle)
+                 SecureRandom.uuid
+               else
+                 @openshift_object.data.uid
+               end
+      end
+
+      private
+
+      def yaml_from_sources
+        cfg = {:sources => [], :updated_at => Time.now.utc.strftime("%Y-%m-%d %H:%M:%S")}
+        sources.each do |source|
+          next unless source.from_sources_api
+
+          cfg[:sources] << {
+            :source => source['uid'],
+            :scheme => source.endpoint['scheme'],
+            :host   => source.endpoint['host'],
+            :port   => source.endpoint['port'],
+            :path   => source.endpoint['path'],
+          }
+        end
+
+        cfg.to_yaml
+      end
+
+      # Updates digests in openshift object's data
+      def update!
+        raise "Missing openshift object" if openshift_object.nil?
+
+        openshift_object.data.digests = digests.to_json
+        openshift_object.data['custom.yml'] = yaml_from_sources
+
+        object_manager.update_config_map(openshift_object)
+
+        secret&.update!
+      end
+
+      def digests
+        return @digests if @digests.present?
+
+        @digests = if openshift_object&.data&.digests.present?
+                     JSON.parse(openshift_object.data.digests)
+                   else
+                     []
+                   end
+      end
+
+      def source_type_by_label
+        openshift_object.metadata.labels[LABEL_SOURCE_TYPE]
+      end
+
+      # Only ConfigMap and Source with same SourceType are compatible
+      def compatible?(source)
+        return false if source_type.nil? || source.source_type.nil?
+
+        source_type['name'] == source.source_type['name']
+      end
+
+      # Maximum sources is set by config
+      def free_slot?
+        current = sources.size
+        max = source_type&.sources_per_collector || 1
+
+        is_free = current < max
+
+        logger.debug("ConfigMap #{self}: Free slot? (max: #{max}, current: #{current}): #{is_free ? 'T' : 'F'}")
+        is_free
+      end
+
+      def new_secret
+        Secret.new(object_manager)
+      end
+
+      def new_deployment_config
+        DeploymentConfig.new(object_manager)
+      end
+
+      def load_openshift_object
+        object_manager.get_config_maps(LABEL_COMMON).detect { |s| s.metadata.labels[LABEL_UNIQUE] == uid }
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/deployment_config.rb
+++ b/lib/topological_inventory/orchestrator/deployment_config.rb
@@ -1,0 +1,105 @@
+require "topological_inventory/orchestrator/openshift_object"
+
+module TopologicalInventory
+  module Orchestrator
+    # Deployment config is maintained by config map
+    # Paired by LABEL_UNIQUE label
+    class DeploymentConfig < OpenshiftObject
+      LABEL_COMMON = "tp-inventory/collector".freeze
+      LABEL_DIGEST = "topological-inventory/collector_digest".freeze # single-source DCs
+      LABEL_UNIQUE = "tp-inventory/config-uid".freeze
+
+      attr_accessor :config_map
+
+      def to_s
+        uid
+      end
+
+      def create_in_openshift
+        raise "Cannot create deployment config, no config map associated" if config_map.nil?
+
+        # Gets image name (defined per source type => same for all sources in config_map)
+        related_source = config_map.sources.detect { |source| source.from_sources_api }
+        if related_source.nil?
+          # This state can happen when someone deletes DC manually
+          #   and all Sources in ConfigMap are marked for deletion
+          logger.warn("Failed to create deployment config, no existing source associated")
+          return
+        end
+        image = related_source.collector_definition["image"]
+
+        logger.info("Creating DeploymentConfig #{self}")
+        object_manager.create_deployment_config(name, ENV["IMAGE_NAMESPACE"], image) do |dc|
+          dc[:metadata][:labels][LABEL_UNIQUE] = uid
+          dc[:metadata][:labels][LABEL_COMMON] = "true"
+          dc[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?
+          dc[:spec][:replicas] = 1
+
+          volumes = dc[:spec][:template][:spec][:volumes]
+          volumes << {
+            :name      => 'sources-config',
+            :configMap => {:name => config_map.name}
+          }
+
+          volumes << {
+            :name   => 'sources-secrets',
+            :secret => {
+              :secretName => config_map.secret&.name
+            }
+          }
+
+          container = dc[:spec][:template][:spec][:containers].first
+          container[:volumeMounts] = []
+          container[:volumeMounts] << {
+            :name => 'sources-config',
+            :mountPath => "/opt/#{config_map.source_type['name']}-collector/config"
+          }
+
+          container[:volumeMounts] << {
+            :name => 'sources-secrets',
+            :mountPath => "/opt/#{config_map.source_type['name']}-collector/secret"
+          }
+          # Environment variables
+          container[:env] = container_env_values
+        end
+        logger.info("[OK] Created DeploymentConfig #{self}")
+      end
+
+      def delete_in_openshift
+        logger.info("Deleting DeploymentConfig #{self}")
+
+        object_manager.delete_deployment_config(name)
+
+        logger.info("[OK] Deleted DeploymentConfig #{self}")
+      end
+
+      # DC config-UID is relation to config-map's template
+      def uid
+        return @uid if @uid.present?
+
+        @uid = if @openshift_object.present? # no openshift_object reloading here (cycle)
+                 @openshift_object.metadata.labels[LABEL_UNIQUE]
+               else
+                 config_map&.uid
+               end
+      end
+
+      def name
+        "tp-inventory-collector-#{uid}"
+      end
+
+      private
+
+      def container_env_values
+        [
+          { :name => "INGRESS_API", :value => "http://#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"]}:#{ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"]}" },
+          { :name => "CONFIG", :value => 'custom'}
+        ]
+      end
+
+      def load_openshift_object
+        object_manager.get_deployment_configs(LABEL_COMMON).detect { |s| s.metadata.labels[LABEL_UNIQUE] == uid }
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/logger.rb
+++ b/lib/topological_inventory/orchestrator/logger.rb
@@ -1,0 +1,19 @@
+require "manageiq/loggers"
+
+module TopologicalInventory
+  module Orchestrator
+    class << self
+      attr_writer :logger
+    end
+
+    def self.logger
+      @logger ||= ManageIQ::Loggers::CloudWatch.new
+    end
+
+    module Logging
+      def logger
+        TopologicalInventory::Orchestrator.logger
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/openshift_object.rb
+++ b/lib/topological_inventory/orchestrator/openshift_object.rb
@@ -1,0 +1,32 @@
+module TopologicalInventory
+  module Orchestrator
+    class OpenshiftObject
+      include Logging
+
+      attr_writer :openshift_object
+
+      def initialize(object_manager, openshift_object = nil)
+        self.object_manager = object_manager
+        self.openshift_object = openshift_object
+      end
+
+      def openshift_object
+        return @openshift_object if @openshift_object.present?
+
+        @openshift_object = load_openshift_object
+      end
+
+      def uid
+        raise NotImplementedError, "#{__method__} must be implemented in a subclass"
+      end
+
+      private
+
+      def load_openshift_object
+        raise NotImplementedError, "#{__method__} must be implemented in a subclass"
+      end
+
+      attr_accessor :object_manager
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/secret.rb
+++ b/lib/topological_inventory/orchestrator/secret.rb
@@ -1,0 +1,89 @@
+require "topological_inventory/orchestrator/openshift_object"
+
+module TopologicalInventory
+  module Orchestrator
+    # Secret is maintained by config map
+    # Paired by LABEL_UNIQUE label
+    class Secret < OpenshiftObject
+      LABEL_COMMON = "tp-inventory/collectors-secret".freeze
+      LABEL_UNIQUE = "tp-inventory/config-uid".freeze
+
+      attr_accessor :config_map
+
+      def to_s
+        uid
+      end
+
+      def create_in_openshift
+        logger.info("Creating Secret #{self}")
+        raise "Cannot create secret, no config map associated" if config_map.nil?
+
+        object_manager.create_secret(name, data) do |secret|
+          secret[:metadata][:labels][LABEL_UNIQUE] = uid
+          secret[:metadata][:labels][LABEL_COMMON] = "true"
+          secret[:metadata][:labels][ConfigMap::LABEL_SOURCE_TYPE] = config_map.source_type['name'] if config_map.source_type.present?
+        end
+
+        logger.info("[OK] Created Secret #{self}")
+      end
+
+      # Updating secret values for all sources attached to related configmap
+      def update!
+        logger.info("Updating Secret #{self}")
+
+        if openshift_object.present?
+          openshift_object.stringData = data
+          object_manager.update_secret(openshift_object)
+
+          logger.info("[OK] Updated Secret #{self}")
+        else
+          logger.warn("Updating Secret - not found: #{self}")
+        end
+      end
+
+      def delete_in_openshift
+        logger.info("Deleting Secret #{self}")
+
+        object_manager.delete_secret(name)
+
+        logger.info("[OK] Deleted Secret #{self}")
+      end
+
+      def name
+        "tp-inventory-secret-#{uid}"
+      end
+
+      # Secret config-UID is relation to config-map's template
+      def uid
+        return @uid if @uid.present?
+
+        @uid = if @openshift_object.present? # no openshift_object reloading here (cycle)
+                 @openshift_object.metadata.labels[LABEL_UNIQUE]
+               else
+                 config_map&.uid
+               end
+      end
+
+      private
+
+      def load_openshift_object
+        object_manager.get_secrets(LABEL_COMMON).detect { |s| s.metadata.labels[LABEL_UNIQUE] == uid }
+      end
+
+      def data
+        data = { 'updated_at' => Time.now.utc.strftime("%Y-%m-%d %H:%M:%S") }
+
+        config_map.sources.each do |source|
+          next unless source.from_sources_api # don't add to secret if removed from API
+
+          data[source['uid']] = {
+            'username' => source.credentials['username'],
+            'password' => source.credentials['password']
+          }
+        end
+
+        { "credentials" => data.to_json }
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/source.rb
+++ b/lib/topological_inventory/orchestrator/source.rb
@@ -1,0 +1,110 @@
+require 'digest'
+require "topological_inventory/orchestrator/api_object"
+
+module TopologicalInventory
+  module Orchestrator
+    class Source < ApiObject
+      attr_accessor :config_map, :source_type, :from_sources_api, :tenant
+      attr_accessor :collector_definition,
+                    :endpoint, :authentication, :credentials
+
+      def to_s
+        name = ''
+        name = attributes['uid'].to_s if attributes.present?
+        name += " (ConfigMap: #{config_map})" if config_map.present?
+        name
+      end
+
+      def initialize(attributes, tenant, source_type, collector_definition, from_sources_api:)
+        super(attributes)
+
+        self.tenant = tenant
+        self.source_type = source_type
+        self.collector_definition = collector_definition
+        self.from_sources_api = from_sources_api
+
+        self.endpoint = nil
+        self.authentication = nil
+        self.credentials = nil
+
+        self.config_map = nil
+      end
+
+      def add_to_openshift(object_manager, config_maps)
+        add_to_existing_collector(config_maps)
+
+        if config_map.nil?
+          deploy_new_collector(object_manager)
+        end
+      end
+
+      def remove_from_openshift
+        config_map&.remove_source(self)
+      end
+
+      def load_credentials(api)
+        self.endpoint = api.get_endpoint(attributes['id'], tenant)
+        return if endpoint.nil?
+
+        self.authentication = api.get_authentication(endpoint['id'], tenant)
+        return if authentication.nil?
+
+        self.credentials = api.get_credentials(authentication['id'], tenant)
+      end
+
+      def digest=(value)
+        @digest = value
+      end
+
+      def digest
+        return @digest if @digest.present?
+        return nil if attributes.nil? || endpoint.nil? || authentication.nil? || credentials.nil?
+
+        @digest = compute_digest(digest_values)
+      end
+
+      private
+
+      def digest_values
+        {
+          "endpoint_host"   => endpoint["host"],
+          "endpoint_path"   => endpoint["path"],
+          "endpoint_port"   => endpoint["port"].to_s,
+          "endpoint_scheme" => endpoint["scheme"],
+          "image"           => collector_definition["image"],
+          "image_namespace" => ENV["IMAGE_NAMESPACE"],
+          "source_id"       => attributes["id"],
+          "source_uid"      => attributes["uid"],
+          "secret"          => {
+            "password" => credentials["password"],
+            "username" => credentials["username"],
+          }
+        }
+      end
+
+      def compute_digest(object)
+        Digest::SHA1.hexdigest(Marshal.dump(object))
+      end
+
+      def name
+        "tp-inventory-collector-#{config_map.uid}"
+      end
+
+      # @return [ConfigMap | nil]
+      def deploy_new_collector(object_manager)
+        ConfigMap.deploy_new(object_manager, self)
+      end
+
+      # Adds source's creds to config map
+      def add_to_existing_collector(config_maps)
+        config_maps.each do |map|
+          next unless map.available?(self)
+
+          map.add_source(self)
+          self.config_map = map
+          break
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/source_type.rb
+++ b/lib/topological_inventory/orchestrator/source_type.rb
@@ -1,0 +1,33 @@
+require "topological_inventory/orchestrator/api_object"
+
+module TopologicalInventory
+  module Orchestrator
+    class SourceType < ApiObject
+      SUPPORTED_TYPES = %w[amazon ansible-tower openshift].freeze
+
+      def to_s
+        attributes['name'] || "Unknown source type: #{attributes.inspect}"
+      end
+
+      def sources_per_collector
+        return @sources_per_collector if @sources_per_collector.present?
+
+        if attributes['name'].present?
+          @sources_per_collector = ::Settings.collectors.sources_per_collector.send(attributes['name']) || 1
+        end
+
+        @sources_per_collector
+      end
+
+      def collector_definition(collector_image_tag = 'latest')
+        if supported_source_type?
+          { "image" => "topological-inventory-#{attributes['name']}:#{collector_image_tag}" }
+        end
+      end
+
+      def supported_source_type?
+        attributes['name'].present? && SUPPORTED_TYPES.include?(attributes['name'])
+      end
+    end
+  end
+end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,0 +1,54 @@
+describe TopologicalInventory::Orchestrator::Api do
+  include MockData
+  include Functions
+
+  describe "#internal_url_for" do
+    let(:api) { TopologicalInventory::Orchestrator::Api.new(:sources_api => sources_api, :topology_api => topology_api) }
+
+    it "replaces the path with /internal/v0.1/<path>" do
+      expect(api.send(:topology_internal_url_for, "the/best/path")).to eq("http://topology.local:8080/internal/v1.0/the/best/path")
+    end
+  end
+
+  describe "#each_resource" do
+    let(:api) { TopologicalInventory::Orchestrator::Api.new(:sources_api => sources_api, :topology_api => topology_api) }
+    let(:path1) { "/api/topological-inventory/v1.0/some_collection" }
+    let(:path2) { "/api/topological-inventory/v1.0/some_collection?offset=10&limit=10" }
+    let(:path3) { "/api/topological-inventory/v1.0/some_collection?offset=20&limit=10" }
+    let(:url1) { "http://example.com:8080#{path1}" }
+    let(:url2) { "http://example.com:8080#{path2}" }
+    let(:url3) { "http://example.com:8080#{path3}" }
+    let(:response1) { { "meta" => {}, "links" => {"first" => path1, "last" => path3, "next" => path2, "prev" => nil}, "data" => [1, 2, 3] }.to_json }
+    let(:response2) { { "meta" => {}, "links" => {"first" => path1, "last" => path3, "next" => path3, "prev" => path1}, "data" => [4, 5, 6] }.to_json }
+    let(:response3) { { "meta" => {}, "links" => {"first" => path1, "last" => path3, "next" => nil, "prev" => path2}, "data" => [7, 8] }.to_json }
+    let(:non_paginated_response) { [1, 2, 3, 4, 5, 6, 7, 8].to_json }
+
+    context "paginated responses" do
+      before do
+        stub_rest_get(url1, user_tenant_header, response1)
+        stub_rest_get(url2, user_tenant_header, response2)
+        stub_rest_get(url3, user_tenant_header, response3)
+      end
+
+      it "with a block" do
+        expect { |b| api.send(:each_resource, url1, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+      end
+
+      it "enumerable" do
+        expect(api.send(:each_resource, url1, user_tenant_account).collect(&:to_i)).to eq([1, 2, 3, 4, 5, 6, 7, 8])
+      end
+    end
+
+    context "non-paginated responses" do
+      it "with a block" do
+        stub_rest_get(url1, user_tenant_header, non_paginated_response)
+        expect { |b| api.send(:each_resource, url1, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
+      end
+
+      it "enumerable" do
+        stub_rest_get(url1, user_tenant_header, non_paginated_response)
+        expect(api.send(:each_resource, url1, user_tenant_account).collect(&:to_i)).to eq([1, 2, 3, 4, 5, 6, 7, 8])
+      end
+    end
+  end
+end

--- a/spec/config_map_spec.rb
+++ b/spec/config_map_spec.rb
@@ -1,0 +1,241 @@
+require 'yaml'
+
+describe TopologicalInventory::Orchestrator::ConfigMap do
+  include MockData
+
+  let(:object_manager) { double('object_manager') }
+  let(:openshift_object) { double('openshift_object') }
+  let(:source) { double('source') }
+  let(:source2) { double('source2') }
+  let(:source_type) { double('source_type') }
+  let(:secret) { double('secret') }
+  let(:deployment_config) { double('deployment_config') }
+
+  let(:config_map) { described_class.new(object_manager, openshift_object) }
+
+  before do
+    allow(source).to receive(:source_type).and_return(source_type)
+    allow(source).to receive(:[]) { |arg| arg == 'uid' ? 'source-1' : nil }
+    allow(source2).to receive(:source_type).and_return(source_type)
+    allow(source2).to receive(:[]) { |arg| arg == 'uid' ? 'source-2' : nil }
+
+    allow(config_map).to receive_messages(
+      :logger                => double('logger').as_null_object,
+      :new_secret            => secret,
+      :new_deployment_config => deployment_config,
+      :source_type           => source_type,
+      :uid                   => '1'
+    )
+
+    config_map_def = { :metadata => { :labels => {} }, :data => {} }
+    allow(object_manager).to receive(:create_config_map).and_yield(config_map_def)
+
+    allow(secret).to receive(:config_map=)
+    allow(deployment_config).to receive(:config_map=)
+  end
+
+  describe "#init_from_source" do
+    before do
+      allow(secret).to receive(:create_in_openshift)
+      allow(deployment_config).to receive(:create_in_openshift)
+
+      allow(config_map).to receive(:yaml_from_sources).and_return("")
+    end
+
+    it "creates secret and deployment_config" do
+      expect(secret).to receive(:create_in_openshift)
+      expect(deployment_config).to receive(:create_in_openshift)
+
+      allow(source_type).to receive(:[]).and_return('source_type-name')
+      allow(source).to receive(:digest).and_return('1234')
+
+      config_map.init_from_source!(source)
+
+      expect(config_map.secret).to eq(secret)
+      expect(config_map.deployment_config).to eq(deployment_config)
+    end
+  end
+
+  context "add or remove" do
+    let(:config_map_data) { OpenStruct.new }
+    let(:endpoint1) { {'scheme' => 'https', 'host' => 'one.example.com', 'port' => 443, 'path' => nil} }
+    let(:endpoint2) { {'scheme' => 'https', 'host' => 'two.example.com', 'port' => 443, 'path' => '/api'} }
+    before do
+      allow(openshift_object).to receive(:data).and_return(config_map_data)
+    end
+
+    describe "#add_source" do
+      it "updates map's data and secret" do
+        digest, digest2 = "12345", "23456"
+        allow(config_map).to receive_messages(:available? => true,
+                                              :digests    => [])
+        allow(source).to receive_messages(:digest           => digest,
+                                          :endpoint         => endpoint1,
+                                          :from_sources_api => true)
+
+        allow(source2).to receive_messages(:digest           => digest2,
+                                           :endpoint         => endpoint2,
+                                           :from_sources_api => true)
+
+        allow(object_manager).to receive(:update_config_map)
+
+        expect(object_manager).to receive(:update_config_map).twice
+
+        # Add both sources to config map
+        [source, source2].each do |s|
+          config_map.add_source(s)
+        end
+
+        expect(config_map.send(:digests)).to eq([digest, digest2])
+        expect(config_map.sources).to eq([source, source2])
+
+        # Get data from openshift object
+        # Compare it with endpoints and source uids
+        loaded_data = YAML.load(config_map_data['custom.yml'])
+        expected_data = [
+          endpoint1.transform_keys!(&:to_sym).merge(:source => source['uid']),
+          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'])
+        ]
+        expect(loaded_data[:sources]).to eq(expected_data)
+      end
+
+      it "adds only source with digest" do
+        allow(config_map).to receive_messages(:available? => true,
+                                              :digests    => [],
+                                              :update!    => nil)
+
+        # Source without digest isn't added
+        allow(source).to receive(:digest).and_return([])
+        config_map.add_source(source)
+        expect(config_map.sources).to eq([])
+
+        # Source with digest is added
+        allow(source).to receive(:digest).and_return("qwerty")
+        config_map.add_source(source)
+        expect(config_map.sources.first).to eq(source)
+      end
+
+      it "cannot add the same source twice" do
+        allow(config_map).to receive_messages(:available? => true,
+                                              :digests    => [],
+                                              :update!    => nil)
+
+        allow(source).to receive(:digest).and_return("qwerty")
+
+        config_map.add_source(source)
+        expect(config_map.sources.size).to eq(1)
+        # 2nd add doesn't have an effect
+        config_map.add_source(source)
+        expect(config_map.sources.size).to eq(1)
+      end
+
+      it "cannot add source of different type" do
+        allow(source).to receive_messages(:digest => nil)
+        allow(source_type).to receive_messages(:sources_per_collector => 1,
+                                               :[]                    => 'source_type-name')
+
+        allow(source).to receive(:source_type).and_return({})
+        expect { config_map.add_source(source) }.to raise_exception("ConfigMap not available")
+      end
+
+      it "cannot add source to full config-map" do
+        allow(source).to receive_messages(:digest      => nil,
+                                          :source_type => source_type)
+        # Max one source
+        allow(source_type).to receive_messages(:sources_per_collector => 1,
+                                               :[]                    => 'source_type-name')
+
+        expect { config_map.add_source(source) }.not_to raise_exception
+        config_map.sources << double
+
+        expect { config_map.add_source(source) }.to raise_exception("ConfigMap not available")
+      end
+    end
+
+    describe "#remove_source" do
+      it "updates map's data and secret" do
+        digest, digest2 = "digest1", "digest2"
+        allow(config_map).to receive_messages(:available?        => true,
+                                              :digests           => [],
+                                              :deployment_config => deployment_config,
+                                              :secret            => secret)
+        allow(source).to receive_messages(:digest           => digest,
+                                          :endpoint         => endpoint1,
+                                          :from_sources_api => true)
+
+        allow(source2).to receive_messages(:digest           => digest2,
+                                           :endpoint         => endpoint2,
+                                           :from_sources_api => true)
+
+        allow(object_manager).to receive(:update_config_map)
+        allow(object_manager).to receive(:delete_config_map)
+
+        allow(secret).to receive(:delete_in_openshift)
+        allow(secret).to receive(:update!)
+        allow(deployment_config).to receive(:delete_in_openshift)
+
+        # 2x add, 1x remove, last remove doesn't update, but delete
+        expect(object_manager).to receive(:update_config_map).exactly(3).times
+        expect(secret).to receive(:update!).exactly(3).times
+
+        # Add both sources to config map
+        config_map.add_source(source)
+        config_map.add_source(source2)
+
+        expect(config_map.send(:digests)).to eq([digest, digest2])
+        expect(config_map.sources).to eq([source, source2])
+
+        # Remove first source
+        config_map.remove_source(source)
+
+        # Get data from openshift object
+        # Compare it with endpoints and source uids
+        loaded_data = YAML.load(config_map_data['custom.yml'])
+        expected_data = [
+          endpoint2.transform_keys!(&:to_sym).merge(:source => source2['uid'])
+        ]
+        expect(loaded_data[:sources]).to eq(expected_data)
+        expect(config_map.sources).to eq([source2])
+
+        # Remove 2nd source
+        expect(object_manager).to receive(:delete_config_map).once
+        expect(deployment_config).to receive(:delete_in_openshift)
+        expect(secret).to receive(:delete_in_openshift)
+        config_map.remove_source(source2)
+      end
+    end
+  end
+
+  describe "#associate_sources" do
+    let(:digests) { (1..5).collect { |i| "digest-#{i}" } }
+
+    it "finds in digests or creates new" do
+      allow(config_map).to receive(:digests).and_return(digests)
+
+      sources_by_digest = {}
+      [2, 4].each do |idx|
+        TopologicalInventory::Orchestrator::Source.new({}, nil, nil, '', :from_sources_api => true).tap do |source|
+          source.digest = digests[idx]
+          sources_by_digest[source.digest] = source
+        end
+      end
+
+      config_map.associate_sources(sources_by_digest)
+
+      expect(config_map.sources.size).to eq(digests.size)
+
+      sources_new = 0
+      config_map.sources.each do |source|
+        expect(source.config_map).to eq(config_map)
+        expect(source.digest).not_to eq(nil)
+        sources_new += 1 unless source.from_sources_api
+      end
+
+      # 5 digests, 2 input sources => 5 - 2 == 3
+      expect(sources_new).to eq(3)
+
+      # input parameter is used later and contains all sources
+      expect(sources_by_digest.keys.sort).to eq(digests.sort)
+    end
+  end
+end

--- a/spec/helpers/functions.rb
+++ b/spec/helpers/functions.rb
@@ -1,0 +1,209 @@
+module Functions
+  include MockData
+
+  # API call stubs for Source, endpoint, authentication(and credentials)
+  def stub_api_source_calls(source)
+    stub_api_source_get(source, show(source))
+    endpoint = endpoints(source)[source['id']]
+    stub_rest_get("#{sources_api}/sources/#{source["id"]}/endpoints", user_tenant_header, list([endpoint]))
+
+    authentication = authentications(source)[source['id']]
+    stub_rest_get("#{sources_api}/endpoints/#{endpoint['id']}/authentications", user_tenant_header, list([authentication]))
+
+    stub_rest_get("#{sources_api(:internal => true)}/authentications/#{authentication['id']}?expose_encrypted_attribute[]=password", user_tenant_header, show(credentials(source)[authentication['id']]))
+  end
+
+  def stub_rest_get(path, tenant_header, response)
+    expect(RestClient).to receive(:get).with(path, tenant_header).and_return(response)
+  end
+
+  def stub_rest_get_404(path, tenant_header)
+    expect(RestClient).to receive(:get).with(path, tenant_header).and_raise(RestClient::NotFound)
+  end
+
+  def stub_rest_patch(path, body, tenant_header)
+    expect(RestClient).to receive(:patch).with(path, body, tenant_header)
+  end
+
+  def stub_api_source_types_get(response)
+    stub_rest_get("#{sources_api}/source_types", orchestrator_tenant_header, response)
+  end
+
+  def stub_api_application_types_get(response)
+    stub_rest_get("#{sources_api}/application_types", orchestrator_tenant_header, response)
+  end
+
+  # Filter is based on TopologicalInventory::Orchestrator::Api#supported_applications_url
+  # and mock_data.rb:application_types_data (id [1,3] includes topological-inventory)
+  def stub_api_applications_get(response)
+    application_query = "filter[application_type_id][eq][]=1&filter[application_type_id][eq][]=3"
+    stub_rest_get("#{sources_api}/applications?#{application_query}", user_tenant_header, response)
+  end
+
+  def stub_api_tenants_get(response)
+    stub_rest_get("#{topology_api(:internal => true)}/tenants", orchestrator_tenant_header, response)
+  end
+
+  def stub_api_source_get(source, response)
+    stub_rest_get("#{sources_api}/sources/#{source["id"]}", user_tenant_header, response)
+  end
+
+  def stub_api_topology_sources_get(response)
+    stub_rest_get("#{topology_api}/sources", user_tenant_header, response)
+  end
+
+  def stub_api_topology_sources_patch(source, body)
+    path = "#{topology_api(:internal => true)}/sources/#{source["id"]}"
+    stub_rest_patch(path, body, user_tenant_header)
+  end
+
+  def stub_api_source_refresh_status_patch(source, status)
+    expect(%w[quota_limited deployed]).to include(status)
+
+    stub_api_topology_sources_patch(source, { 'refresh_status' => status}.to_json)
+  end
+
+  # Initialize basic api calls which are called everytime
+  # GET <sources_api>/source_types,
+  # GET <tp-inv_api>/internal/tenants,
+  # GET <tp-inv_api/sources
+  #
+  # @param[String<JSON>] source_types, tenants, topology_sources
+  def stub_api_init(source_types:, tenants:, application_types:, applications:, topology_sources:)
+    stub_api_source_types_get(source_types)
+    stub_api_applications_get(applications)
+    stub_api_application_types_get(application_types)
+    stub_api_tenants_get(tenants)
+    stub_api_topology_sources_get(topology_sources)
+  end
+
+  def list(data)
+    { :links => {}, :data => data }.to_json
+  end
+
+  def show(data)
+    data.to_json
+  end
+
+  def stub_settings_merge(hash)
+    if defined?(::Settings)
+      Settings.add_source!(hash)
+      Settings.reload!
+    end
+  end
+
+  def init_config(openshift: 1, amazon: 1, azure: 1, mock: 1)
+    stub_settings_merge(:collectors => {
+      :sources_per_collector => {
+        :amazon    => amazon,
+        :azure     => azure,
+        :mock      => mock,
+        :openshift => openshift
+      }
+    })
+  end
+
+  ### Assert checks agains kube_client
+  def assert_openshift_objects_count(cnt)
+    expect(kube_client.config_maps.size).to eq(cnt)
+    expect(kube_client.deployment_configs.size).to eq(cnt)
+    expect(kube_client.secrets.size).to eq(cnt)
+  end
+
+  def assert_openshift_objects_data(source_data, missing: false)
+    config_uid = assert_source_in_config_maps(source_data, :missing => missing)
+    assert_source_in_secrets(source_data, config_uid, :missing => missing)
+  end
+
+  def assert_source_in_config_maps(source_data, missing: false)
+    found_digests, found_in_yaml = 0, 0
+    config_uid = nil
+
+    kube_client.config_maps.each_pair do |_name, config_map|
+      source_source_type = source_type_for(source_data)&.send(:[], 'name')
+      map_source_type = config_map.metadata.labels[TopologicalInventory::Orchestrator::ConfigMap::LABEL_SOURCE_TYPE.to_sym]
+
+      expect(map_source_type).to be_present
+
+      # Search config map if it contains digest of this source
+      expect(config_map.data.digests).to be_present
+      digests = JSON.parse(config_map.data.digests)
+
+      if (found_digest = digests.include?(digests_data[source_data['id']]))
+        found_digests += 1
+
+        # When found, check that source is in config_map of the same source_type
+        expect(map_source_type == source_source_type)
+
+        # Get config id
+        config_uid = config_map.metadata.labels[TopologicalInventory::Orchestrator::ConfigMap::LABEL_UNIQUE.to_sym]
+      end
+
+      # Search config map if it contains source in custom.yml
+      data = YAML.load(config_map.data['custom.yml'])
+      data[:sources].each do |yaml_source|
+        if yaml_source[:source] == source_data['uid']
+          found_in_yaml += 1
+          expect(found_digest)
+
+          # Check that endpoint data are written to custom.yml
+          endpoint = endpoints(source_data)[source_data['id']]
+
+          expect(endpoint['scheme']).to eq(yaml_source[:scheme])
+          expect(endpoint['host']).to eq(yaml_source[:host])
+          expect(endpoint['port']).to eq(yaml_source[:port])
+          expect(endpoint['path']).to eq(yaml_source[:path])
+        end
+      end
+    end
+
+    if missing
+      # If checked for missing data, source wasn't found
+      expect(found_digests).to eq(0)
+      expect(found_in_yaml).to eq(0)
+    else
+      # Otherwise ensure that data are written only once
+      expect(found_digests).to eq(1)
+      expect(found_in_yaml).to eq(1)
+    end
+
+    config_uid
+  end
+
+  def assert_source_in_secrets(source_data, config_uid, missing: false)
+    found_cnt = 0
+    kube_client.secrets.each_value do |secret|
+      expect(secret.stringData.credentials).to be_present
+      data = JSON.parse(secret.stringData.credentials)
+
+      if (secret_creds = data[source_data['uid']]).present?
+        found_cnt += 1
+        # Check that authentication data are written to secret's data
+        auth = credentials(source_data)[source_data['id']]
+
+        expect(auth['username']).to eq(secret_creds['username'])
+        expect(auth['password']).to eq(secret_creds['password'])
+
+        # Check we're in secret connected to config map with the same UID
+        secret_uid = secret.metadata.labels[TopologicalInventory::Orchestrator::Secret::LABEL_UNIQUE.to_sym]
+        expect(secret_uid).to eq(config_uid)
+      end
+    end
+
+    expect(found_cnt).to eq(missing ? 0 : 1)
+  end
+
+  def assert_deployment_config(_source_data, config_uid)
+    found = false
+    kube_client.deployment_configs.each_value do |dc|
+      break if found
+
+      dc_uid = dc.metadata.labels[TopologicalInventory::Orchestrator::DeploymentConfig::LABEL_UNIQUE.to_sym]
+      found = dc_uid == config_uid
+    end
+
+    expect(found).to eq(true)
+
+    # TODO: Check mounts
+  end
+end

--- a/spec/helpers/mock_data.rb
+++ b/spec/helpers/mock_data.rb
@@ -1,0 +1,241 @@
+module MockData
+  def sources_api(internal: false)
+    if internal
+      "http://sources.local:8080/internal/v1.0"
+    else
+      "http://sources.local:8080/api/sources/v1.0"
+    end
+  end
+
+  def topology_api(internal: false)
+    if internal
+      "http://topology.local:8080/internal/v1.0"
+    else
+      "http://topology.local:8080/api/topological-inventory/v1.0"
+    end
+  end
+
+  def user_tenant_account
+    "12345"
+  end
+
+  def user_tenant_header
+    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1In19"}
+  end
+
+  def orchestrator_tenant_header
+    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6InN5c3RlbV9vcmNoZXN0cmF0b3IifX0="}
+  end
+
+  def tenants
+    {
+      :user => {"id" => "1", "external_tenant" => user_tenant_account}
+    }
+  end
+
+  def source_types_data
+    {
+      :openshift => {"id" => "1", "name" => "openshift", "product_name" => "OpenShift", "vendor" => "Red Hat"},
+      :amazon    => {"id" => "2", "name" => "amazon", "product_name" => "Amazon AWS", "vendor" => "Amazon"},
+      :azure     => {"id" => "3", "name" => "azure", "product_name" => "Azure", "vendor" => "Azure"},
+      :mock      => {"id" => "4", "name" => "mock", "product_name" => "Azure", "vendor" => "Azure"}
+    }
+  end
+
+  def sources_data
+    hash = {}
+
+    add_source(hash, '1', :type => :openshift, :uid => 'cacebc33-1ed8-49d4-b4f9-713f2552ee65')
+    add_source(hash, '2', :type => :openshift, :uid => '31b5338b-685d-4056-ba39-d00b4d7f19cc')
+    add_source(hash, '3', :type => :openshift, :uid => '95f057b7-ec11-4f04-b155-e54dcd5b01aa')
+    add_source(hash, '4', :type => :amazon, :uid => '15493710-8a96-4516-a0de-a9349ba61b9c')
+    add_source(hash, '5', :type => :amazon, :uid => 'a3e42e0b-0902-4911-a0cd-356bd3cf684e')
+    add_source(hash, '6', :type => :amazon, :uid => '86094174-5ae9-476b-8ff5-7c24e01e380d')
+    add_source(hash, '7', :type => :azure, :uid => '4a31b8be-57fc-44e6-899d-d92c3ccc6552')
+    add_source(hash, '8', :type => :azure, :uid => '9fe99b8c-2cfa-43d8-a695-bf01a535f897')
+    add_source(hash, '9', :type => :azure, :uid => 'e4c89509-7177-4f56-8fcc-3015c390c4e7')
+    add_source(hash, '10', :type => :mock, :uid => '8d8d6d75-a1c0-417c-933e-c8f254307cb1')
+    add_source(hash, '11', :type => :mock, :uid => '232dce7e-0f89-4601-8796-f3af43618f62')
+    add_source(hash, '12', :type => :mock, :uid => 'bfd2da99-722b-4ba3-9606-393c1b8c79f4')
+
+    hash
+  end
+
+  def topological_sources
+    hash = {}
+
+    add_source(hash, '1', :topological => true, :type => :openshift, :uid => 'cacebc33-1ed8-49d4-b4f9-713f2552ee65')
+    add_source(hash, '2', :topological => true, :type => :openshift, :uid => '31b5338b-685d-4056-ba39-d00b4d7f19cc')
+    add_source(hash, '3', :topological => true, :type => :openshift, :uid => '95f057b7-ec11-4f04-b155-e54dcd5b01aa')
+    add_source(hash, '4', :topological => true, :type => :amazon, :uid => '15493710-8a96-4516-a0de-a9349ba61b9c')
+    add_source(hash, '5', :topological => true, :type => :amazon, :uid => 'a3e42e0b-0902-4911-a0cd-356bd3cf684e')
+    add_source(hash, '6', :topological => true, :type => :amazon, :uid => '86094174-5ae9-476b-8ff5-7c24e01e380d')
+    add_source(hash, '7', :topological => true, :type => :azure, :uid => '4a31b8be-57fc-44e6-899d-d92c3ccc6552')
+    add_source(hash, '8', :topological => true, :type => :azure, :uid => '9fe99b8c-2cfa-43d8-a695-bf01a535f897')
+    add_source(hash, '9', :topological => true, :type => :azure, :uid => 'e4c89509-7177-4f56-8fcc-3015c390c4e7')
+    add_source(hash, '10', :topological => true, :type => :mock, :uid => '8d8d6d75-a1c0-417c-933e-c8f254307cb1')
+    add_source(hash, '11', :topological => true, :type => :mock, :uid => '232dce7e-0f89-4601-8796-f3af43618f62')
+    add_source(hash, '12', :topological => true, :type => :mock, :uid => 'bfd2da99-722b-4ba3-9606-393c1b8c79f4')
+
+    hash
+  end
+
+  def application_types_data
+    [
+      {
+        :dependent_applications         => ["/insights/platform/topological-inventory"],
+        :display_name                   => "Catalog",
+        :id                             => '1',
+        :name                           => "/insights/platform/catalog",
+        :supported_authentication_types => {:ansible_tower => ["username_password"]},
+        :supported_source_types         => ["ansible_tower"]
+      },
+      {
+        :dependent_applications         => [],
+        :display_name                   => "Cost Management",
+        :id                             => "2",
+        :name                           => "/insights/platform/cost-management",
+        :supported_authentication_types => {:amazon => ["arn"]},
+        :supported_source_types         => ["amazon"]
+      },
+      {
+        :dependent_applications         => [],
+        :display_name                   => "Topological Inventory",
+        :id                             => "3",
+        :name                           => "/insights/platform/topological-inventory",
+        :supported_authentication_types => {
+          :amazon        => ["access_key_secret_key"],
+          :ansible_tower => ["username_password"],
+          :azure         => ["username_password"],
+          :openshift     => ["token"]
+        },
+        :supported_source_types         => ["amazon", "ansible_tower", "azure", "openshift"]
+      }
+    ]
+  end
+
+  def applications_data(source = nil)
+    hash = {}
+
+    if source.nil?
+      sources_data.each_pair do |_type, sources_hash|
+        sources_hash.each_key do |id|
+          hash[id] = add_application(id)
+        end
+      end
+    else
+      hash[source['id']] = add_application(source['id'])
+    end
+    hash
+  end
+
+  def endpoints(source = nil)
+    hash = {}
+
+    if source.nil?
+      sources_data.each_pair do |_type, sources_hash|
+        sources_hash.each_key do |id|
+          hash[id] = add_endpoint(id)
+        end
+      end
+    else
+      hash[source['id']] = add_endpoint(source['id'])
+    end
+    hash
+  end
+
+  def authentications(source = nil)
+    hash = {}
+
+    if source.nil?
+      sources_data.each_pair do |_type, sources_hash|
+        sources_hash.each_key do |id|
+          hash[id] = add_authentication(id)
+        end
+      end
+    else
+      hash[source['id']] = add_authentication(source['id'])
+    end
+    hash
+  end
+
+  def credentials(source = nil)
+    hash = {}
+
+    if source.nil?
+      sources_data.each_pair do |_type, sources_hash|
+        sources_hash.each_key do |id|
+          hash[id] = add_credential(id)
+        end
+      end
+    else
+      hash[source['id']] = add_credential(source['id'])
+    end
+    hash
+  end
+
+  # Values are for source + endpoint + credentials of the same ID
+  def digests_data
+    {
+      '1'  => '1d9e34af4e70ad44a47c74aebe0cf74d3980c887',
+      '2'  => '8d4fc3e19f141135ca59f0ba5d9e8b634f04840e',
+      '3'  => 'ee53859fd0b58430b75907894600b77755674b01',
+      '4'  => '98a148ffce1fb8c6875f4b6dc8bd2935b0bb868a',
+      '5'  => '3acba9bf43755682f00942ab56cbf995cd75a702',
+      '6'  => '741fc03f04725dcdda91168ae21750a0b7352ce4',
+      '7'  => '9e48b19ce700bf9535de5b99737c7467965d0b5e',
+      '8'  => '5f9e781563ab48e7a67ec4500321b1ebe553f3fc',
+      '9'  => '8b14bf8dfa2bc7d74443cd9c4a0d836f1341becb',
+      '10' => '5442273b216f7c843de10acc57c33638f7848f74',
+      '11' => '3871068443e406fbff7ad6f91bd395bf9482a259',
+      '12' => '9e52c47b63dd968ba2349779a86986eff2f2b860'
+    }
+  end
+
+  def source_type_for(source)
+    source_types_data.values.detect { |type| type['id'] == source['source_type_id'] }
+  end
+
+  private
+
+  def add_source(out, id, topological: false, type:, uid:)
+    out[type] ||= {}
+    new_source = if topological
+                   {
+                     'id'        => id.to_s,
+                     'uid'       => uid,
+                     'tenant_id' => '1'
+                   }
+                 else
+                   {
+                     'id'             => id.to_s,
+                     'source_type_id' => (source_types_data[type] || {})['id'],
+                     'name'           => "#{type}#{id}",
+                     'uid'            => uid,
+                     'tenant'         => user_tenant_account
+                   }
+                 end
+    out[type][id] = new_source
+    new_source
+  end
+
+  # 1:1 source-application
+  def add_application(source_id)
+    { 'id' => source_id.to_s, 'application_type_id' => '1', 'source_id' => source_id.to_s, 'tenant_id' => '1' }
+  end
+
+  # 1:1 source-endpoint
+  def add_endpoint(source_id)
+    { 'id' => source_id.to_s, 'source_id' => source_id.to_s, 'default' => true, 'tenant_id' => '1', "host" => "example.com", "path" => "/api", "port" => 8443, "scheme" => "https"}
+  end
+
+  # 1:1:1 source-endpoint-authentication
+  def add_authentication(source_id)
+    { 'id' => source_id.to_s, 'resource_id' => source_id.to_s, 'resource_type' => 'Endpoint', 'tenant_id' => '1'}
+  end
+
+  # 1:1 with authentication (same records)
+  def add_credential(source_id)
+    { 'id' => source_id.to_s, 'username' => 'admin', 'password' => 'smartvm', 'resource_id' => source_id.to_s, 'resource_type' => 'Endpoint', 'tenant_id' => '1'}
+  end
+end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,0 +1,71 @@
+describe TopologicalInventory::Orchestrator::Source do
+  include MockData
+
+  let(:collector_definition) { { "image" => "topological-inventory-openshift:latest" } }
+
+  before do
+    @source = described_class.new(sources_data[:openshift]["1"], nil,
+                                  double, collector_definition,
+                                  :from_sources_api => true)
+  end
+
+  context "#add_to_openshift" do
+    let(:config_maps) { [double, double, double] }
+
+    it "with free config_map" do
+      allow(config_maps[0]).to receive(:available?).and_return(false)
+      allow(config_maps[1]).to receive(:available?).and_return(true)
+      allow(config_maps[2]).to receive(:available?).and_return(false)
+      config_maps.each { |map| allow(map).to receive(:add_source) }
+
+      expect(config_maps[1]).to receive(:add_source).once
+
+      @source.add_to_openshift(double, config_maps)
+      expect(@source.config_map).to eq(config_maps[1])
+    end
+
+    it "with no or no free config map" do
+      allow(@source).to receive(:deploy_new_collector)
+      expect(@source).to receive(:deploy_new_collector)
+
+      @source.add_to_openshift(double, [])
+
+      config_maps.each { |map| allow(map).to receive(:available?).and_return(false) }
+
+      allow(@source).to receive(:deploy_new_collector)
+      expect(@source).to receive(:deploy_new_collector)
+
+      @source.add_to_openshift(double, config_maps)
+    end
+  end
+
+  context "#remove_from_openshift" do
+    it "removes it from config map" do
+      config_map = double("config_map")
+      @source.config_map = config_map
+
+      expect(config_map).to receive(:remove_source)
+
+      @source.remove_from_openshift
+    end
+  end
+
+  context "#load_credentials" do
+    it "calls api 3 times" do
+      endpoint, authentication, credentials = double, double, double
+      allow(endpoint).to receive(:[])
+      allow(authentication).to receive(:[])
+
+      api = double("api")
+      allow(api).to receive_messages(:get_endpoint       => endpoint,
+                                     :get_authentication => authentication,
+                                     :get_credentials    => credentials)
+
+      @source.load_credentials(api)
+
+      expect(@source.endpoint).to eq(endpoint)
+      expect(@source.authentication).to eq(authentication)
+      expect(@source.credentials).to eq(credentials)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,4 +99,7 @@ RSpec.configure do |config|
 =end
 end
 
+require "helpers/mock_data"
+require "helpers/functions"
 require 'topological_inventory-orchestrator'
+require "topological_inventory/orchestrator/test_models/object_manager"

--- a/spec/topological_inventory/orchestrator/test_models/kube_client.rb
+++ b/spec/topological_inventory/orchestrator/test_models/kube_client.rb
@@ -1,0 +1,117 @@
+module TopologicalInventory
+  module Orchestrator
+    module TestModels
+      # This class is intended as mock openshift storage
+      class KubeClient
+        attr_accessor :config_maps, :deployment_configs,
+                      :secrets, :endpoints,
+                      :replication_controllers
+        # {
+        #   name => [RecursiveOpenStruct*]
+        # }*
+        def initialize
+          self.config_maps = {}
+          self.deployment_configs = {}
+          self.secrets = {}
+          self.endpoints = {}
+          self.replication_controllers = {}
+        end
+
+        def get_config_maps(label_selector:, namespace:)
+          find_by_label(config_maps, label_selector)
+        end
+
+        def get_deployment_configs(label_selector:, namespace:)
+          find_by_label(deployment_configs, label_selector)
+        end
+
+        def get_replication_controllers(label_selector:, namespace:)
+          find_by_label(replication_controllers, label_selector)
+        end
+
+        def get_secrets(label_selector:, namespace:)
+          find_by_label(secrets, label_selector)
+        end
+
+        def get_deployment_config(name, _namespace)
+          deployment_configs[name]
+        end
+
+        def get_endpoint(name, _namespace)
+          endpoints[name]
+        end
+
+        def create_config_map(definition)
+          add_definition(config_maps, definition)
+        end
+
+        def create_deployment_config(definition)
+          add_definition(deployment_configs, definition)
+        end
+
+        def create_secret(definition)
+          add_definition(secrets, definition)
+        end
+
+        # Noop, _map was updated outside
+        def update_config_map(_map)
+          nil
+        end
+
+        # Noop, _secret was updated outside
+        def update_secret(_secret)
+          nil
+        end
+
+        # Now only for scaling, skipped
+        def patch_deployment_config(_name, _changes_hash, _namespace)
+          nil
+        end
+
+        def delete_config_map(name, _namespace)
+          config_maps.delete(name)
+        end
+
+        def delete_deployment_config(name, _namespace, delete_options:)
+          deployment_configs.delete(name)
+        end
+
+        def delete_secret(name, _namespace)
+          secrets.delete(name)
+        end
+
+        private
+
+        # Collection is in format
+        # {
+        #   (name => RecursiveOpenStruct)*
+        # }
+        def find_by_label(collection, label_selector)
+          out = []
+
+          label_key_value = label_selector.split("=")
+
+          collection.each_value do |struct|
+            struct.metadata.labels.to_h.each_pair do |label_name, label_value|
+              if label_key_value.size == 2
+                if label_key_value[0].to_sym == label_name && label_key_value[1] == label_value
+                  out << struct
+                end
+              else
+                out << struct if label_selector.to_sym == label_name
+              end
+            end
+          end
+
+          out
+        end
+
+        def add_definition(collection, hash)
+          raise "Missing name when adding! #{hash[:metadata].inspect}" if hash[:metadata][:name].blank?
+
+          collection[hash[:metadata][:name]] = RecursiveOpenStruct.new(hash)
+        end
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/orchestrator/test_models/object_manager.rb
+++ b/spec/topological_inventory/orchestrator/test_models/object_manager.rb
@@ -1,0 +1,29 @@
+require_relative "kube_client"
+
+module TopologicalInventory
+  module Orchestrator
+    module TestModels
+      class ObjectManager < TopologicalInventory::Orchestrator::ObjectManager
+        def self.available?
+          true
+        end
+
+        def initialize(kube_connection = nil)
+          @kube_connection = kube_connection
+        end
+
+        def connection
+          kube_connection
+        end
+
+        def kube_connection
+          @kube_connection ||= TopologicalInventory::Orchestrator::TestModels::KubeClient
+        end
+
+        def check_deployment_config_quota(definition)
+          # Noop
+        end
+      end
+    end
+  end
+end

--- a/spec/worker_black_box_spec.rb
+++ b/spec/worker_black_box_spec.rb
@@ -1,0 +1,279 @@
+describe TopologicalInventory::Orchestrator::Worker do
+  include Functions
+
+  around do |e|
+    ENV["IMAGE_NAMESPACE"] = "buildfactory"
+    e.run
+    ENV.delete("IMAGE_NAMESPACE")
+  end
+
+  let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
+  let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
+
+  # Predefined responses
+  let(:empty_list_response) { list([]) }
+  let(:tenants_response) { list([tenants[:user]]) }
+  let(:application_types_response) { list(application_types_data) }
+  let(:applications_response) { list(applications_data.values) }
+
+  subject do
+    allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
+    described_class.new(:collector_image_tag => "dev", :sources_api => sources_api, :topology_api => topology_api)
+  end
+
+  before do
+    # Turn off logger
+    allow(TopologicalInventory::Orchestrator).to receive(:logger).and_return(double('logger').as_null_object)
+
+    # Get testing object_manager/kube_client
+    allow(subject).to receive(:object_manager).and_return(object_manager)
+
+    # Disable Quota test in this spec
+    allow(subject.api).to receive(:update_topological_inventory_source_refresh_status).and_return(nil)
+
+    # Count number of added and removed sources
+    @added, @removed = 0, 0
+    allow_any_instance_of(TopologicalInventory::Orchestrator::Source).to receive(:add_to_openshift).and_wrap_original do |m, *args|
+      m.call(*args)
+      @added += 1
+    end
+    allow_any_instance_of(TopologicalInventory::Orchestrator::Source).to receive(:remove_from_openshift).and_wrap_original do |m, *args|
+      m.call(*args)
+      @removed += 1
+    end
+  end
+
+  context "loads no data in API, empty openshift" do
+    before do
+      # Init of api calls
+      stub_api_init(:application_types => application_types_response,
+                    :applications      => empty_list_response,
+                    :source_types      => empty_list_response,
+                    :tenants           => tenants_response,
+                    :topology_sources  => empty_list_response)
+    end
+
+    it "doesn't create or remove collector" do
+      # Run orchestrator
+      subject.send(:make_openshift_match_database)
+
+      # Check add/remove calls
+      expect(@added).to eq(0)
+      expect(@removed).to eq(0)
+
+      # Check against "Openshift" (Mock KubeClient)
+      assert_openshift_objects_count(0)
+    end
+  end
+
+  context "loads data from API, empty openshift," do
+    let(:source_types_response) { list(source_types_data.values) }
+
+    before do
+      # Init of api calls
+      stub_api_init(:application_types => application_types_response,
+                    :applications      => applications_response,
+                    :source_types      => source_types_response,
+                    :tenants           => tenants_response,
+                    :topology_sources  => topology_sources_response) # defined in sub-contexts
+    end
+
+    context "with sources of the same source_type (openshift)," do
+      let(:topology_sources_response) { list(topological_sources[:openshift].values) }
+      let(:sources_size) { sources_data[:openshift].keys.size }
+
+      (1..3).each do |sources_per_collector|
+        it "#{sources_per_collector} sources per collector" do
+          # Init config
+          init_config(:openshift => sources_per_collector)
+
+          # Init Source API calls
+          sources_data[:openshift].each_value { |source| stub_api_source_calls(source) }
+
+          # Run orchestrator
+          subject.send(:make_openshift_match_database)
+
+          # Check add/remove calls
+          expect(@added).to eq(sources_size)
+          expect(@removed).to eq(0)
+
+          # Check against "Openshift" (Mock KubeClient)
+          objects_cnt = sources_size / sources_per_collector
+          objects_cnt += 1 if sources_size % sources_per_collector > 0
+
+          assert_openshift_objects_count(objects_cnt)
+
+          sources_data[:openshift].each_value { |source| assert_openshift_objects_data(source) }
+        end
+      end
+    end
+
+    context "with sources of different types," do
+      let(:topology_sources_response) { list(topological_sources[:openshift].values + topological_sources[:amazon].values) }
+      let(:sources_size) { sources_data[:openshift].keys.size + sources_data[:amazon].keys.size }
+
+      (1..3).each do |sources_per_collector|
+        it "#{sources_per_collector} sources per config_map" do
+          # Init config
+          init_config(:openshift => sources_per_collector,
+                      :amazon    => sources_per_collector)
+
+          # Init Source API calls
+          sources_data[:openshift].each_value { |source| stub_api_source_calls(source) }
+          sources_data[:amazon].each_value { |source| stub_api_source_calls(source) }
+
+          # Run orchestrator
+          subject.send(:make_openshift_match_database)
+
+          # Check add/remove calls
+          expect(@added).to eq(sources_size)
+          expect(@removed).to eq(0)
+
+          # Check against "Openshift" (Mock KubeClient)
+          objects_cnt = 0
+          %i[openshift amazon].each do |source_type_name|
+            objects_cnt += sources_data[source_type_name].keys.size / sources_per_collector
+            objects_cnt += 1 if sources_data[source_type_name].keys.size % sources_per_collector > 0
+          end
+          assert_openshift_objects_count(objects_cnt)
+
+          sources_data[:openshift].each_value { |source| assert_openshift_objects_data(source) }
+          sources_data[:amazon].each_value { |source| assert_openshift_objects_data(source) }
+        end
+      end
+    end
+
+    context "with sources of unsupported type" do
+      let(:topology_sources_response) { list(topological_sources[:mock].values) }
+      let(:sources_size) { sources_data[:mock].keys.size }
+
+      it "doesn't create any object" do
+        # only source/<id> is called, then it doesn't fit to collected source types
+        sources_data[:mock].each_value { |s| stub_api_source_get(s, show(s)) }
+
+        subject.send(:make_openshift_match_database)
+        expect(@added).to eq(0)
+      end
+    end
+  end
+
+  context "loads data from both API and OpenShift," do
+    let(:source_types_response) { list(source_types_data.values) }
+
+    context "without API data" do
+      before do
+        # Fill openshift first
+        #
+        # 1st sync
+        #
+        @sources_in_openshift = topological_sources[:openshift].values + topological_sources[:amazon].values
+
+        stub_api_init(:application_types => application_types_response,
+                      :applications      => applications_response,
+                      :source_types      => source_types_response,
+                      :tenants           => tenants_response,
+                      :topology_sources  => list(@sources_in_openshift))
+
+        init_config(:openshift => 1, :amazon => 2) # per collector
+
+        sources_data[:openshift].each_value { |s| stub_api_source_calls(s) }
+        sources_data[:amazon].each_value { |s| stub_api_source_calls(s) }
+
+        subject.send(:make_openshift_match_database)
+        expect(@added).to eq(@sources_in_openshift.size)
+
+        assert_openshift_objects_count(3 + 2) # 3 for openshift, 2 for amazon
+        @added = 0 # reset
+      end
+
+      it "removes OpenShift objects" do
+        #
+        # 2nd sync
+        #
+        stub_api_init(:application_types => application_types_response,
+                      :applications      => applications_response,
+                      :source_types      => source_types_response,
+                      :tenants           => tenants_response,
+                      :topology_sources  => empty_list_response)
+
+        subject.send(:make_openshift_match_database)
+
+        expect(@added).to eq(0)
+        expect(@removed).to eq(@sources_in_openshift.size)
+
+        assert_openshift_objects_count(0)
+      end
+    end
+
+    context "with nonempty API data" do
+      before do
+        stub_const("TopologicalInventory::Orchestrator::SourceType::SUPPORTED_TYPES", %w[openshift amazon azure])
+        # Fill openshift first
+        #
+        # 1st sync
+        #
+        @sources_in_openshift = [topological_sources[:openshift]['1'],
+                                 topological_sources[:openshift]['2'],
+                                 topological_sources[:amazon]['4'],
+                                 topological_sources[:amazon]['5']]
+
+        stub_api_init(:application_types => application_types_response,
+                      :applications      => applications_response,
+                      :source_types      => source_types_response,
+                      :tenants           => tenants_response,
+                      :topology_sources  => list(@sources_in_openshift))
+
+        init_config(:openshift => 1, :amazon => 1, :azure => 1) # per collector
+
+        stub_api_source_calls(sources_data[:openshift]['1'])
+        stub_api_source_calls(sources_data[:openshift]['2'])
+        stub_api_source_calls(sources_data[:amazon]['4'])
+        stub_api_source_calls(sources_data[:amazon]['5'])
+
+        # Run orchestrator
+        subject.send(:make_openshift_match_database)
+        expect(@added).to eq(@sources_in_openshift.size)
+
+        assert_openshift_objects_count(2 + 2) # 2 for openshift, 2 for amazon
+
+        @added = 0 # reset
+      end
+
+      it "adds new, keeps existing, removes missing sources" do
+        #
+        # 2nd sync
+        #
+        # added 1 azure + 1 amazon, deleted 1 openshift + 1 amazon
+        sources_from_api = [topological_sources[:openshift]['1'],
+                            topological_sources[:amazon]['4'],
+                            topological_sources[:amazon]['6'], # new
+                            topological_sources[:azure]['7']]  # new
+
+        stub_api_init(:application_types => application_types_response,
+                      :applications      => applications_response,
+                      :source_types      => source_types_response,
+                      :tenants           => tenants_response,
+                      :topology_sources  => list(sources_from_api))
+
+        stub_api_source_calls(sources_data[:openshift]['1'])
+        stub_api_source_calls(sources_data[:amazon]['4'])
+        stub_api_source_calls(sources_data[:amazon]['6'])
+        stub_api_source_calls(sources_data[:azure]['7'])
+
+        # Run orchestrator
+        subject.send(:make_openshift_match_database)
+
+        expect(@added).to eq(2)
+        expect(@removed).to eq(2)
+
+        assert_openshift_objects_count(1 + 1 + 2) # openshift + azure + amazon
+        assert_openshift_objects_data(sources_data[:openshift]['1'])
+        assert_openshift_objects_data(sources_data[:openshift]['2'], :missing => true)
+        assert_openshift_objects_data(sources_data[:amazon]['4'])
+        assert_openshift_objects_data(sources_data[:amazon]['5'], :missing => true)
+        assert_openshift_objects_data(sources_data[:amazon]['6']) # added
+        assert_openshift_objects_data(sources_data[:azure]['7']) # added
+      end
+    end
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,27 +1,5 @@
 describe TopologicalInventory::Orchestrator::Worker do
-  let(:tenants_response) do
-    <<~EOJ
-      {
-        "links": {},
-        "data": [
-          {
-            "id": "1",
-            "external_tenant": "#{user_tenant_account}"
-          }
-        ]
-      }
-    EOJ
-  end
-
-  let(:orchestrator_tenant_header) do
-    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6InN5c3RlbV9vcmNoZXN0cmF0b3IifX0="}
-  end
-
-  let(:user_tenant_account) { "12345" }
-
-  let(:user_tenant_header) do
-    {"x-rh-identity" => "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1In19"}
-  end
+  include Functions
 
   around do |e|
     ENV["IMAGE_NAMESPACE"] = "buildfactory"
@@ -29,295 +7,73 @@ describe TopologicalInventory::Orchestrator::Worker do
     ENV.delete("IMAGE_NAMESPACE")
   end
 
-  subject { described_class.new(collector_image_tag: "dev", sources_api: sources_api, topology_api: topology_api) }
+  let(:kube_client) { TopologicalInventory::Orchestrator::TestModels::KubeClient.new }
+  let(:object_manager) { TopologicalInventory::Orchestrator::TestModels::ObjectManager.new(kube_client) }
 
-  let(:sources_api)  { "http://sources.local:8080/api/sources/v1.0" }
-  let(:topology_api) { "http://topology.local:8080/api/topological-inventory/v0.1" }
+  # Predefined responses
+  let(:empty_list_response) { list([]) }
+  let(:tenants_response) { list([tenants[:user]]) }
+  let(:source_types_response) { list(source_types_data.values) }
+  let(:application_types_response) { list(application_types_data) }
+  let(:applications_response) { list(applications_data.values) }
 
-  context "#collectors_from_sources_api" do
-    let(:source_types_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","name":"openshift","product_name":"OpenShift","vendor":"Red Hat"},
-            {"id":"2","name":"amazon","product_name":"Amazon AWS","vendor":"Amazon"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:application_types_response) do
-      <<~EOJ
-        {
-          "data": [
-            {
-                "dependent_applications": ["/insights/platform/topological-inventory"],
-                "display_name": "Catalog",
-                "id": "1",
-                "name": "/insights/platform/catalog",
-                "supported_authentication_types": {"ansible_tower": ["username_password"]},
-                "supported_source_types": ["ansible_tower"]
-            },
-            {
-                "dependent_applications": [],
-                "display_name": "Cost Management",
-                "id": "2",
-                "name": "/insights/platform/cost-management",
-                "supported_authentication_types": {"amazon": ["arn"]},
-                "supported_source_types": ["amazon"]
-            },
-            {
-                "dependent_applications": [],
-                "display_name": "Topological Inventory",
-                "id": "3",
-                "name": "/insights/platform/topological-inventory",
-                "supported_authentication_types": {
-                    "amazon": ["access_key_secret_key"],
-                    "ansible_tower": ["username_password"],
-                    "azure": ["username_password"],
-                    "openshift": ["token"]
-                },
-                "supported_source_types": ["amazon", "ansible_tower", "azure", "openshift"]
-            }
-          ],
-          "links": {
-          }
-        }
-      EOJ
-    end
-
-    let(:applications_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","application_type_id":"1","source_id":"1","tenant_id":"1"},
-            {"id":"2","application_type_id":"1","source_id":"2","tenant_id":"1"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:topology_sources_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","uid":"cacebc33-1ed8-49d4-b4f9-713f2552ee65","tenant_id":"1"},
-            {"id":"2","uid":"31b5338b-685d-4056-ba39-d00b4d7f19cc","tenant_id":"1"},
-            {"id":"3","uid":"95f057b7-ec11-4f04-b155-e54dcd5b01aa","tenant_id":"1"},
-            {"id":"4","uid":"2c187e9b-7442-474c-bdc4-da47bf9553fc","tenant_id":"1"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:sources_1_response) do
-      <<~EOJ
-        {
-          "id":"1","source_type_id":"1","name":"mock-source","uid":"cacebc33-1ed8-49d4-b4f9-713f2552ee65","tenant":"#{user_tenant_account}"
-        }
-      EOJ
-    end
-
-    let(:sources_2_response) do
-      <<~EOJ
-        {
-          "id":"2","source_type_id":"1","name":"OCP","uid":"31b5338b-685d-4056-ba39-d00b4d7f19cc","tenant":"#{user_tenant_account}"
-        }
-      EOJ
-    end
-
-    let(:sources_3_response) do
-      <<~EOJ
-        {
-          "id":"3","source_type_id":"2","name":"AWS","uid":"95f057b7-ec11-4f04-b155-e54dcd5b01aa","tenant":"#{user_tenant_account}"
-        }
-      EOJ
-    end
-
-    let(:sources_1_endpoints_response) { {"links" => {}, "data" => []}.to_json }
-
-    let(:sources_2_endpoints_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","default":true,"host":"example.com","path":"/api","port":8443,"scheme":"https","source_id":"2","tenant_id":"1","role":"default"},
-            {"id":"8","default":true,"host":"example.com","path":"/api","port":8443,"scheme":"https","source_id":"2","tenant_id":"1","role":"nothing"},
-            {"id":"9","default":true,"host":"example.com","path":"/api","port":8443,"scheme":"https","source_id":"2","tenant_id":"1"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:endpoints_1_authentications_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","authtype":"default"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:endpoints_8_authentications_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": []
-        }
-      EOJ
-    end
-
-    it "generates the expected hash" do
-      stub_rest_get("#{sources_api}/source_types", orchestrator_tenant_header, source_types_response)
-
-      stub_rest_get("#{sources_api}/application_types", orchestrator_tenant_header, application_types_response)
-      stub_rest_get("http://topology.local:8080/internal/v1.0/tenants", orchestrator_tenant_header, tenants_response)
-
-      application_query = "filter[application_type_id][eq][]=1&filter[application_type_id][eq][]=3"
-      stub_rest_get("#{sources_api}/applications?#{application_query}", user_tenant_header, applications_response)
-      stub_rest_get("#{topology_api}/sources", user_tenant_header, topology_sources_response)
-
-      stub_rest_get("#{sources_api}/sources/1", user_tenant_header, sources_1_response)
-      stub_rest_get("#{sources_api}/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
-
-      stub_rest_get("#{sources_api}/sources/2", user_tenant_header, sources_2_response)
-      stub_rest_get("#{sources_api}/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
-      stub_rest_get("#{sources_api}/endpoints/1/authentications", user_tenant_header, endpoints_1_authentications_response)
-      stub_rest_get("http://sources.local:8080/internal/v1.0/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
-
-      stub_rest_get("#{sources_api}/sources/3", user_tenant_header, sources_3_response)
-
-      stub_rest_get_404("#{sources_api}/sources/4", user_tenant_header)
-
-      expect(RestClient).not_to receive(:get).with("#{sources_api}/endpoints/8/authentications", any_args)
-      expect(RestClient).not_to receive(:get).with("#{sources_api}/endpoints/9/authentications", any_args)
-      expect(RestClient).not_to receive(:get).with("http://sources.local:8080/internal/v1.0/authentications/8?expose_encrypted_attribute[]=password", any_args)
-      expect(RestClient).not_to receive(:get).with("http://sources.local:8080/internal/v1.0/authentications/9?expose_encrypted_attribute[]=password", any_args)
-
-      collector_hash = subject.send(:collectors_from_sources_api)
-
-      expect(collector_hash).to eq(
-        "98d6f0dbd5219b970d6161fcd1c4d0284fa51d48" => {
-          "endpoint_host"   => "example.com",
-          "endpoint_path"   => "/api",
-          "endpoint_port"   => "8443",
-          "endpoint_scheme" => "https",
-          "image"           => "topological-inventory-openshift:dev",
-          "image_namespace" => "buildfactory",
-          "source_id"       => "2",
-          "source_uid"      => "31b5338b-685d-4056-ba39-d00b4d7f19cc",
-          "secret"          => {
-            "password" => "PASS",
-            "username" => "USER"
-          },
-          "tenant"          => user_tenant_account,
-        }
-      )
-    end
+  subject do
+    allow(described_class).to receive(:path_to_config).and_return(File.expand_path("../config", File.dirname(__FILE__)))
+    described_class.new(:collector_image_tag => "dev", :sources_api => sources_api, :topology_api => topology_api)
   end
 
-  describe "#internal_url_for" do
-    it "replaces the path with /internal/v0.1/<path>" do
-      expect(subject.send(:topology_internal_url_for, "the/best/path")).to eq("http://topology.local:8080/internal/v1.0/the/best/path")
-    end
+  before do
+    # Turn off logger
+    allow(TopologicalInventory::Orchestrator).to receive(:logger).and_return(double('logger').as_null_object)
+
+    # Get testing object_manager/kube_client
+    allow(subject).to receive(:object_manager).and_return(object_manager)
   end
 
-  describe "#each_resource" do
-    let(:path_1) { "/api/topological-inventory/v1.0/some_collection" }
-    let(:path_2) { "/api/topological-inventory/v1.0/some_collection?offset=10&limit=10" }
-    let(:path_3) { "/api/topological-inventory/v1.0/some_collection?offset=20&limit=10" }
-    let(:url_1) { "http://example.com:8080#{path_1}" }
-    let(:url_2) { "http://example.com:8080#{path_2}" }
-    let(:url_3) { "http://example.com:8080#{path_3}" }
-    let(:response_1) { {"meta" => {}, "links" => {"first" => path_1, "last" => path_3, "next" => path_2, "prev" => nil}, "data" => [1, 2, 3]}.to_json }
-    let(:response_2) { {"meta" => {}, "links" => {"first" => path_1, "last" => path_3, "next" => path_3, "prev" => path_1}, "data" => [4, 5, 6]}.to_json }
-    let(:response_3) { {"meta" => {}, "links" => {"first" => path_1, "last" => path_3, "next" => nil, "prev" => path_2}, "data" => [7, 8]}.to_json }
-    let(:non_paginated_response) { [1, 2, 3, 4, 5, 6, 7, 8].to_json }
+  describe "#quotas" do
+    let(:topology_sources_response) { list(topological_sources[:openshift].values) }
+    let(:sources_size) { sources_data[:openshift].keys.size }
 
-    context "paginated responses" do
-      it "with a block" do
-        stub_rest_get(url_1, user_tenant_header, response_1)
-        stub_rest_get(url_2, user_tenant_header, response_2)
-        stub_rest_get(url_3, user_tenant_header, response_3)
-
-        expect { |b| subject.send(:each_resource, url_1, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
-      end
-
-      it "enumerable" do
-        stub_rest_get(url_1, user_tenant_header, response_1)
-        stub_rest_get(url_2, user_tenant_header, response_2)
-        stub_rest_get(url_3, user_tenant_header, response_3)
-
-        expect(subject.send(:each_resource, url_1, user_tenant_account).collect(&:to_i)).to eq([1, 2, 3, 4, 5, 6, 7, 8])
-      end
+    before do
+      # Init of api calls
+      stub_api_init(:application_types => application_types_response,
+                    :applications      => applications_response,
+                    :source_types      => source_types_response,
+                    :tenants           => tenants_response,
+                    :topology_sources  => topology_sources_response)
+      init_config
     end
-
-    context "non-paginated responses" do
-      it "with a block" do
-        stub_rest_get(url_1, user_tenant_header, non_paginated_response)
-
-        expect { |b| subject.send(:each_resource, url_1, user_tenant_account, &b) }.to yield_successive_args(1, 2, 3, 4, 5, 6, 7, 8)
-      end
-
-      it "enumerable" do
-        stub_rest_get(url_1, user_tenant_header, non_paginated_response)
-
-        expect(subject.send(:each_resource, url_1, user_tenant_account).collect(&:to_i)).to eq([1, 2, 3, 4, 5, 6, 7, 8])
-      end
-    end
-  end
-
-  describe "#create_openshift_objects_for_source" do
-    let(:args)       { {"secret" => "secret", "source_id" => "1", "tenant" => user_tenant_account} }
-    let(:connection) { double("Connection") }
 
     it "successful" do
-      expect(subject.logger).to receive(:info).with("Creating objects for source 1 with digest digest")
-      expect(subject.logger).to receive(:info).with("Secret topological-inventory-collector-source-1-secrets created for source 1")
-      expect(subject.logger).to receive(:info).with("DeploymentConfig topological-inventory-collector-source-1 created for source 1")
-      expect(subject.send(:object_manager)).to receive(:create_secret).with("topological-inventory-collector-source-1-secrets", "secret")
-      expect(subject.send(:object_manager)).to receive(:check_deployment_config_quota)
-      expect(subject.send(:object_manager)).to receive(:connection).and_return(connection)
-      expect(connection).to receive(:create_deployment_config)
+      # Init Source API calls
+      sources_data[:openshift].each_value do |source_data|
+        stub_api_source_calls(source_data)
+        stub_api_source_refresh_status_patch(source_data, "deployed")
+      end
 
-      expect(RestClient).to receive(:patch).with(
-        "http://topology.local:8080/internal/v1.0/sources/1",
-        "{\"refresh_status\":\"deployed\"}",
-        user_tenant_header
-      )
+      expect(subject.send(:object_manager)).to receive(:check_deployment_config_quota).exactly(sources_size).times
+      # Run orchestrator
+      subject.send(:make_openshift_match_database)
 
-      subject.send(:create_openshift_objects_for_source, "digest", args)
+      # Test number of objects in OpenShift
+      assert_openshift_objects_count(sources_size)
     end
 
     it "failed quota check" do
-      expect(subject.logger).to receive(:info).with("Creating objects for source 1 with digest digest")
-      expect(subject.logger).to receive(:info).with("Secret topological-inventory-collector-source-1-secrets created for source 1")
-      expect(subject.logger).to receive(:info).with("Skipping Deployment Config creation for source 1 because it would exceed quota.")
-      expect(subject.send(:object_manager)).to receive(:create_secret).with("topological-inventory-collector-source-1-secrets", "secret")
-      expect(subject.send(:object_manager)).to receive(:check_deployment_config_quota).and_raise(::TopologicalInventory::Orchestrator::ObjectManager::QuotaCpuLimitExceeded)
-      allow(subject.send(:object_manager)).to receive(:connection).and_return(connection)
-      expect(connection).not_to receive(:create_deployment_config)
+      # Init Source API calls
+      sources_data[:openshift].each_value do |source_data|
+        stub_api_source_calls(source_data)
+        stub_api_source_refresh_status_patch(source_data, "quota_limited")
+      end
 
-      expect(RestClient).to receive(:patch).with(
-        "http://topology.local:8080/internal/v1.0/sources/1",
-        "{\"refresh_status\":\"quota_limited\"}",
-        user_tenant_header
-      )
+      expect(subject.send(:object_manager)).to receive(:check_deployment_config_quota).and_raise(::TopologicalInventory::Orchestrator::ObjectManager::QuotaCpuLimitExceeded).exactly(sources_size).times
 
-      subject.send(:create_openshift_objects_for_source, "digest", args)
+      expect(kube_client).not_to receive(:create_deployment_config)
+
+      # Run orchestrator
+      subject.send(:make_openshift_match_database)
+
+      assert_openshift_objects_count(0)
     end
-  end
-
-  def stub_rest_get(path, tenant_header, response)
-    expect(RestClient).to receive(:get).with(path, tenant_header).and_return(response)
-  end
-
-  def stub_rest_get_404(path, tenant_header)
-    expect(RestClient).to receive(:get).with(path, tenant_header).and_raise(RestClient::NotFound)
   end
 end


### PR DESCRIPTION
## How it works

This PR reads sources from API and assigns each source to ConfigMap, Secret and DeploymentConfig. Each collector can collect more sources (of the same SourceType) now.

Each SourceType (allowed) has assigned `sources_per_collector` value (yaml file `config/default.yml`).

Each Source is associated with one Config map. ConfigMap can group sources of the same type to the amount up to `sources_per_collector`. 

Each ConfigMap is identified by UUID and labeled by source type.
For each ConfigMap there is created Secret and DeploymentConfig. 

ConfigMap and Secret are mapped to filesystem to `<app_dir>/config/custom.yml`, `<app_dir>/secrets/credentials`. These values are periodically read by collector (so adding/removing of source doesn't need restart of pod).

Single-source(old) deployment configs will be deleted automatically after restarting orchestrator with this code (detected by label `topological-inventory/collector_digest`)

## Self-recovery
If any of config-map, secret or deployment config is deleted manually (outside of orchestrator), orchestrator detects it and creates missing openshift objects

## Filtering in openshift (labels)

- label `tp-inventory/config_uid` (Unique label)
  -  each ConfigMap and assocaited Secret and DeploymentConfig
- label `tp-inventory/source-type` 
  - filtering by source type
- label `tp-inventory/collectors-config-map`
  - all config maps 
- label `tp-inventory/collector`
  - all deployment configs
- label `tp-inventory/collectors-secret`
  - all secrets
- ???
  - Source can be identified only by config maps's data

## Links

**depends on**
- [x] https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/22
- [x] https://github.com/ManageIQ/topological_inventory-amazon/pull/36
- [x] https://github.com/ManageIQ/topological_inventory-ansible_tower/pull/23
- [x] https://github.com/ManageIQ/topological_inventory-openshift/pull/98

**related**
- [ ] https://github.com/RedHatInsights/e2e-deploy/pull/580