### PR TITLE
Reduce the number of applications API calls

### DIFF
--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -171,16 +171,18 @@ module TopologicalInventory
 
       # Set of ids for supported applications
       def supported_application_type_ids
+        supported_applications_filter = URI.escape(SUPPORTED_APPLICATIONS.collect { |sa| "filter[name][eq][]=#{sa}" }.join("&"))
+
         ids = []
-        each_resource(sources_api_url_for("application_types")) do |application_type|
-          ids << application_type["id"] if SUPPORTED_APPLICATIONS.include?(application_type["name"])
+        each_resource(sources_api_url_for("application_types?#{supported_applications_filter}")) do |app_type|
+          ids << app_type["id"]
         end
         ids
       end
 
       # URL to get a list of applications for supported application types
       def supported_applications_url
-        query = CGI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq][]=#{id}" }.join("&"))
+        query = URI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq][]=#{id}" }.join("&"))
         sources_api_url_for("applications?#{query}")
       end
 

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -180,7 +180,7 @@ module TopologicalInventory
 
       # URL to get a list of applications for supported application types
       def supported_applications_url
-        query = CGI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq]=#{id}" }.join("&"))
+        query = CGI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq][]=#{id}" }.join("&"))
         sources_api_url_for("applications?#{query}")
       end
 

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -63,6 +63,13 @@ module TopologicalInventory
         each_resource(sources_api_url_for("source_types")) { |source_type| source_types_by_id[source_type["id"]] = source_type }
 
         each_tenant do |tenant|
+          # Query applications for the supported application_types, then later we can check if the source
+          # has any supported applications from this hash
+          applications_by_source_id = Hash.new { |hash, key| hash[key] = [] }
+          each_resource(supported_applications_url, tenant) do |application|
+            applications_by_source_id[application["source_id"]] << application
+          end
+
           each_resource(topology_api_url_for("sources"), tenant) do |topology_source|
             source = get_and_parse(sources_api_url_for("sources", topology_source["id"]), tenant)
             next if source.nil?
@@ -71,10 +78,7 @@ module TopologicalInventory
 
             next unless (collector_definition = collector_definitions[source_type["name"]])
 
-            application_types = get_and_parse(sources_api_url_for("sources", source["id"], "application_types"), tenant)
-
-            enabled_applications = application_types["data"].map { |app_type| app_type["name"] }
-            next if (SUPPORTED_APPLICATIONS & enabled_applications).empty?
+            next if applications_by_source_id[source["id"]].empty?
 
             endpoints = get_and_parse(sources_api_url_for("sources", source["id"], "endpoints"), tenant)
             next unless (endpoint = endpoints&.dig("data")&.first)
@@ -163,6 +167,21 @@ module TopologicalInventory
 
       def each_tenant
         each_resource(topology_internal_url_for("tenants")) { |tenant| yield tenant["external_tenant"] }
+      end
+
+      # Set of ids for supported applications
+      def supported_application_type_ids
+        ids = []
+        each_resource(sources_api_url_for("application_types")) do |application_type|
+          ids << application_type["id"] if SUPPORTED_APPLICATIONS.include?(application_type["name"])
+        end
+        ids
+      end
+
+      # URL to get a list of applications for supported application types
+      def supported_applications_url
+        query = CGI.escape(supported_application_type_ids.map { |id| "filter[application_type_id][eq]=#{id}" }.join("&"))
+        sources_api_url_for("applications?#{query}")
       end
 
       # HACK: for Authentications

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -47,6 +47,31 @@ describe TopologicalInventory::Orchestrator::Worker do
       EOJ
     end
 
+    let(:application_types_response) do
+      <<~EOJ
+        {
+          "links": {},
+          "data": [
+            {"id":"1","display_name":"Catalog","name":"/insights/platform/catalog"},
+            {"id":"2","display_name": "Cost Management","name":"/insights/platform/cost-management"},
+            {"id":"3","display_name": "Topological Inventory","name":"/insights/platform/topological-inventory"}
+          ]
+        }
+      EOJ
+    end
+
+    let(:applications_response) do
+      <<~EOJ
+        {
+          "links": {},
+          "data": [
+            {"id":"1","application_type_id":"1","source_id":"1","tenant_id":"1"},
+            {"id":"2","application_type_id":"1","source_id":"2","tenant_id":"1"}
+          ]
+        }
+      EOJ
+    end
+
     let(:topology_sources_response) do
       <<~EOJ
         {
@@ -120,56 +145,24 @@ describe TopologicalInventory::Orchestrator::Worker do
       EOJ
     end
 
-    let(:sources_1_application_types_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","name":"/insights/platform/catalog","display_name":"Catalog"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:sources_2_application_types_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","name":"/insights/platform/catalog","display_name":"Catalog"}
-          ]
-        }
-      EOJ
-    end
-
-    let(:sources_3_application_types_response) do
-      <<~EOJ
-        {
-          "links": {},
-          "data": [
-            {"id":"1","name":"/insights/platform/cost-management","display_name":"Cost Management"}
-          ]
-        }
-      EOJ
-    end
-
     it "generates the expected hash" do
       stub_rest_get("#{sources_api}/source_types", orchestrator_tenant_header, source_types_response)
+      stub_rest_get("#{sources_api}/application_types", orchestrator_tenant_header, application_types_response)
       stub_rest_get("http://topology.local:8080/internal/v1.0/tenants", orchestrator_tenant_header, tenants_response)
+
+      application_type_query = "filter%5Bapplication_type_id%5D%5Beq%5D%3D1%26filter%5Bapplication_type_id%5D%5Beq%5D%3D3"
+      stub_rest_get("#{sources_api}/applications?#{application_type_query}", user_tenant_header, applications_response)
       stub_rest_get("#{topology_api}/sources", user_tenant_header, topology_sources_response)
 
       stub_rest_get("#{sources_api}/sources/1", user_tenant_header, sources_1_response)
-      stub_rest_get("#{sources_api}/sources/1/application_types", user_tenant_header, sources_1_application_types_response)
       stub_rest_get("#{sources_api}/sources/1/endpoints", user_tenant_header, sources_1_endpoints_response)
 
       stub_rest_get("#{sources_api}/sources/2", user_tenant_header, sources_2_response)
-      stub_rest_get("#{sources_api}/sources/2/application_types", user_tenant_header, sources_2_application_types_response)
       stub_rest_get("#{sources_api}/sources/2/endpoints", user_tenant_header, sources_2_endpoints_response)
       stub_rest_get("#{sources_api}/endpoints/1/authentications", user_tenant_header, endpoints_1_authentications_response)
       stub_rest_get("http://sources.local:8080/internal/v1.0/authentications/1?expose_encrypted_attribute[]=password", user_tenant_header, {"username" => "USER", "password" => "PASS"}.to_json)
 
       stub_rest_get("#{sources_api}/sources/3", user_tenant_header, sources_3_response)
-      stub_rest_get("#{sources_api}/sources/3/application_types", user_tenant_header, sources_3_application_types_response)
 
       stub_rest_get_404("#{sources_api}/sources/4", user_tenant_header)
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -147,11 +147,16 @@ describe TopologicalInventory::Orchestrator::Worker do
 
     it "generates the expected hash" do
       stub_rest_get("#{sources_api}/source_types", orchestrator_tenant_header, source_types_response)
-      stub_rest_get("#{sources_api}/application_types", orchestrator_tenant_header, application_types_response)
+
+      application_type_query = "filter[name][eq][]=/insights/platform/catalog&"\
+                               "filter[name][eq][]=/insights/platform/topological-inventory"
+      stub_rest_get("#{sources_api}/application_types?#{application_type_query}",
+                    orchestrator_tenant_header, application_types_response)
       stub_rest_get("http://topology.local:8080/internal/v1.0/tenants", orchestrator_tenant_header, tenants_response)
 
-      application_type_query = "filter%5Bapplication_type_id%5D%5Beq%5D%5B%5D%3D1%26filter%5Bapplication_type_id%5D%5Beq%5D%5B%5D%3D3"
-      stub_rest_get("#{sources_api}/applications?#{application_type_query}", user_tenant_header, applications_response)
+      application_query = "filter[application_type_id][eq][]=1&"\
+                          "filter[application_type_id][eq][]=2&filter[application_type_id][eq][]=3"
+      stub_rest_get("#{sources_api}/applications?#{application_query}", user_tenant_header, applications_response)
       stub_rest_get("#{topology_api}/sources", user_tenant_header, topology_sources_response)
 
       stub_rest_get("#{sources_api}/sources/1", user_tenant_header, sources_1_response)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -150,7 +150,7 @@ describe TopologicalInventory::Orchestrator::Worker do
       stub_rest_get("#{sources_api}/application_types", orchestrator_tenant_header, application_types_response)
       stub_rest_get("http://topology.local:8080/internal/v1.0/tenants", orchestrator_tenant_header, tenants_response)
 
-      application_type_query = "filter%5Bapplication_type_id%5D%5Beq%5D%3D1%26filter%5Bapplication_type_id%5D%5Beq%5D%3D3"
+      application_type_query = "filter%5Bapplication_type_id%5D%5Beq%5D%5B%5D%3D1%26filter%5Bapplication_type_id%5D%5Beq%5D%5B%5D%3D3"
       stub_rest_get("#{sources_api}/applications?#{application_type_query}", user_tenant_header, applications_response)
       stub_rest_get("#{topology_api}/sources", user_tenant_header, topology_sources_response)
 


### PR DESCRIPTION
Query applications for supported application_types once per tenant
instead of once per source.