### PR TITLE
Changed DC deleting policy to Background

### DIFF
--- a/lib/topological_inventory/orchestrator/object_manager.rb
+++ b/lib/topological_inventory/orchestrator/object_manager.rb
@@ -61,10 +61,10 @@ module TopologicalInventory
 
         scale(name, 0)
         delete_options = Kubeclient::Resource.new(
-          :apiVersion         => 'meta/v1',
+          :apiVersion         => 'v1',
           :gracePeriodSeconds => 0,
           :kind               => 'DeleteOptions',
-          :propagationPolicy  => 'Foreground' # Orphan, Foreground, or Background
+          :propagationPolicy  => 'Background' # Orphan, Foreground, or Background
         )
         connection.delete_deployment_config(name, my_namespace, :delete_options => delete_options)
         delete_replication_controller(rc.metadata.name) if rc


### PR DESCRIPTION
Foreground policy doesn't work with current master, because DC is marked for deletion and before all deployments are deleted, then orchestrator runs new round and creates new DC with the same name (which is obviously the same object in openshift) - and this leads to some zombie state.