### PR TITLE
Removing invalid source log

### DIFF
--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -121,11 +121,7 @@ module TopologicalInventory
           Source.new(attributes, tenant, source_type, collector_definition, :from_sources_api => true).tap do |source|
             source.load_credentials(@api)
 
-            if source.digest.present?
-              @sources_by_digest[source.digest] = source
-            else
-              logger.error("Source #{source} invalid, no data for digest")
-            end
+            @sources_by_digest[source.digest] = source if source.digest.present?
           end
         end
 


### PR DESCRIPTION
It seems `Source 022abaf2-ac6b-43d1-a057-259f8a4281e6 invalid, no data for digest` is kibana killer, so better to remove this log