### PR TITLE
Event driven orchestrator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "cloudwatchlogger", "~>0.2"
 gem "config", "~> 1.7.2"
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.4"
+gem 'manageiq-messaging',   '~> 0.1.5'
 gem "more_core_extensions", "~>3.7.0"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"

--- a/lib/topological_inventory/orchestrator/event_manager.rb
+++ b/lib/topological_inventory/orchestrator/event_manager.rb
@@ -19,7 +19,6 @@ module TopologicalInventory
 
       def initialize(worker)
         self.worker = worker
-        self.sync_semaphore = Mutex.new
         self.queue = Queue.new
       end
 
@@ -32,7 +31,7 @@ module TopologicalInventory
 
       private
 
-      attr_accessor :queue, :sync_semaphore, :worker
+      attr_accessor :queue, :worker
       #
       # Event listener invokes sync when received event from Sources API
       #
@@ -79,12 +78,9 @@ module TopologicalInventory
       end
 
       def process_event(event_name, model_id = nil)
-        # Just one sync at the same time
-        sync_semaphore.synchronize do
-          msg = "Sync started by event #{event_name}: id [#{model_id.presence || '---'}]"
-          logger.send(model_id.present? ? :info : :debug, msg) # Info log only for Sources API events
-          worker.make_openshift_match_database
-        end
+        msg = "Sync started by event #{event_name}: id [#{model_id.presence || '---'}]"
+        logger.send(model_id.present? ? :info : :debug, msg) # Info log only for Sources API events
+        worker.make_openshift_match_database
       end
 
       def persist_ref

--- a/lib/topological_inventory/orchestrator/event_manager.rb
+++ b/lib/topological_inventory/orchestrator/event_manager.rb
@@ -1,0 +1,129 @@
+module TopologicalInventory
+  module Orchestrator
+    class EventManager
+      include Logging
+
+      ORCHESTRATOR_EVENT_NAME = "Orchestrator.sync".freeze
+      SYNC_EVENT_INTERVAL = 1.hour
+      SKIP_SUBSEQUENT_EVENTS_DURATION = 5.seconds
+
+      def self.run!(worker)
+        manager = new(worker)
+        manager.run!
+      end
+
+      def initialize(worker)
+        self.worker = worker
+        self.event_semaphore = Mutex.new
+        self.sync_semaphore  = Mutex.new
+        self.last_event_at = nil
+        self.publisher_sleep_time = 0
+      end
+
+      def run!
+        Thread.new { listener }
+        loop { publisher }
+      end
+
+      private
+
+      attr_accessor :event_semaphore, :last_event_at,
+                    :publisher_sleep_time, :sync_semaphore, :worker
+
+      def listener
+        messaging_client.subscribe_topic(subscribe_opts) do |message|
+          begin
+            if events.include?(message.message)
+              Thread.new { process_event } # Ack message, don't wait
+            end
+          rescue => err
+            logger.error("#{err} | #{err.backtrace.join("\n")}")
+          end
+        end
+      ensure
+        messaging_client&.close
+      end
+
+      # Publisher invokes sync event once per hour if no other event came
+      def publisher
+        event_semaphore.synchronize do
+          self.publisher_sleep_time = if last_event_at.nil? || (Time.now.utc - last_event_at > SYNC_EVENT_INTERVAL)
+                                        publish_sync_event
+                                        SYNC_EVENT_INTERVAL + 5.seconds # 5 seconds for kafka delivery delay
+                                      else
+                                        [SYNC_EVENT_INTERVAL - (Time.now.utc - last_event_at).to_i, 0].max
+                                      end
+        end
+        sleep(publisher_sleep_time)
+      end
+
+      # Sources UI (through API) generates multiple events
+      # for one update, just 1 should be processed
+      def process_event
+        event_semaphore.synchronize do
+          if last_event_at.nil? || (Time.now.utc - last_event_at > SKIP_SUBSEQUENT_EVENTS_DURATION)
+            self.last_event_at = Time.now.utc
+          else
+            return
+          end
+        end
+
+        sleep(SKIP_SUBSEQUENT_EVENTS_DURATION)
+
+        # Just one sync at the same time
+        sync_semaphore.synchronize do
+          worker.make_openshift_match_database
+        end
+      end
+
+      def persist_ref
+        "topological-inventory-orchestrator"
+      end
+
+      def queue_name
+        "platform.sources.event-stream"
+      end
+
+      # Orchestrator is listening to these events
+      # (digest is created from these models)
+      def events
+        return @events if @events.present?
+
+        @events = %w[Source Endpoint Authentication Application].collect do |model|
+          %W[#{model}.create #{model}.update #{model}.destroy]
+        end.flatten
+        @events << ORCHESTRATOR_EVENT_NAME
+        @events
+      end
+
+      def publish_sync_event
+        publish_opts = {
+          :service => queue_name,
+          :event   => ORCHESTRATOR_EVENT_NAME,
+          :payload => {}.to_json
+        }
+
+        messaging_client.publish_topic(publish_opts)
+      end
+
+      def messaging_client
+        @messaging_client ||= ManageIQ::Messaging::Client.open(
+          :protocol    => :Kafka,
+          :host        => ENV["QUEUE_HOST"] || "localhost",
+          :port        => ENV["QUEUE_PORT"] || "9092",
+          :group_ref   => persist_ref,
+          :persist_ref => persist_ref,
+          :encoding    => "json"
+        )
+      end
+
+      def subscribe_opts
+        {
+          :persist_ref     => persist_ref,
+          :service         => queue_name,
+          :session_timeout => 60 # seconds
+        }
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -46,7 +46,7 @@ module TopologicalInventory
           loop do
             make_openshift_match_database
 
-            sleep 10
+            sleep 10.seconds
           end
         else
           EventManager.run!(self)

--- a/lib/topological_inventory/orchestrator/worker.rb
+++ b/lib/topological_inventory/orchestrator/worker.rb
@@ -3,6 +3,7 @@ require "base64"
 require "config"
 require "json"
 require "manageiq-password"
+require "manageiq-messaging"
 require "more_core_extensions/core_ext/hash"
 require "rest-client"
 require "yaml"
@@ -12,6 +13,7 @@ require "topological_inventory/orchestrator/object_manager"
 require "topological_inventory/orchestrator/api"
 require "topological_inventory/orchestrator/config_map"
 require "topological_inventory/orchestrator/deployment_config"
+require "topological_inventory/orchestrator/event_manager"
 require "topological_inventory/orchestrator/secret"
 require "topological_inventory/orchestrator/source_type"
 require "topological_inventory/orchestrator/source"
@@ -40,24 +42,14 @@ module TopologicalInventory
       def run
         remove_single_source_deployments
 
-        loop do
-          make_openshift_match_database
+        if ENV['NO_KAFKA']
+          loop do
+            make_openshift_match_database
 
-          sleep 10
-        end
-      end
-
-      private
-
-      # Removing of (old) single-source deployment configs
-      # TODO: can be removed after first deployment
-      def remove_single_source_deployments
-        dcs = object_manager.get_deployment_configs("topological-inventory/collector=true").select do |dc|
-          dc.metadata.labels[TopologicalInventory::Orchestrator::DeploymentConfig::LABEL_DIGEST].present?
-        end
-
-        dcs.each do |dc|
-          object_manager.delete_deployment_config(dc.metadata.name)
+            sleep 10
+          end
+        else
+          EventManager.run!(self)
         end
       end
 
@@ -83,6 +75,20 @@ module TopologicalInventory
         # Remove unused openshift objects
         remove_old_deployments
         remove_old_secrets
+      end
+
+      private
+
+      # Removing of (old) single-source deployment configs
+      # TODO: can be removed after first deployment
+      def remove_single_source_deployments
+        dcs = object_manager.get_deployment_configs("topological-inventory/collector=true").select do |dc|
+          dc.metadata.labels[TopologicalInventory::Orchestrator::DeploymentConfig::LABEL_DIGEST].present?
+        end
+
+        dcs.each do |dc|
+          object_manager.delete_deployment_config(dc.metadata.name)
+        end
       end
 
       def object_manager

--- a/spec/topological_inventory/orchestrator/event_manager_spec.rb
+++ b/spec/topological_inventory/orchestrator/event_manager_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe TopologicalInventory::Orchestrator::EventManager do
+  let(:worker) { double("worker") }
+  let(:message) { double("Message") }
+
+  subject { described_class.new(worker) }
+
+  before do
+    # Turn off logger
+    allow(TopologicalInventory::Orchestrator).to receive(:logger).and_return(double('logger').as_null_object)
+
+    allow(subject).to receive(:sleep)
+    allow(message).to receive(:payload).and_return('id' => '1')
+
+    @mutex = Mutex.new
+    @cv = ConditionVariable.new
+    @sync_invoked = 0
+  end
+
+  describe "#scheduled_sync" do
+    it "doesn't invoke sync in less than hour" do
+      subject.send(:last_event_at=, Time.now.utc - 5.minutes)
+      expect(subject).not_to receive(:process_event)
+      subject.send(:scheduled_sync)
+    end
+
+    it "invokes sync after an hour" do
+      subject.send(:last_event_at=, Time.now.utc - 1.hour)
+      stub_process_event
+      subject.send(:scheduled_sync)
+
+      assert_process_event_calls_count(1)
+    end
+
+    it "invokes sync when orchestrator starts" do
+      subject.send(:last_event_at=, nil)
+      stub_process_event
+      subject.send(:scheduled_sync)
+
+      assert_process_event_calls_count(1)
+    end
+  end
+
+  describe "#listener" do
+    let(:messaging_client) { double("Kafka Client") }
+
+    before do
+      allow(subject).to receive(:messaging_client).and_return(messaging_client)
+      allow(messaging_client).to receive(:subscribe_topic) do |_, &block|
+        block.call(message)
+      end
+      allow(messaging_client).to receive(:close)
+    end
+
+    it "processes only allowed events" do
+      stub_process_event
+
+      # Unsupported events
+      allow(message).to receive(:message).and_return("Source.custom")
+      subject.send(:listener)
+      allow(message).to receive(:message).and_return("Not.interesting.event")
+      subject.send(:listener)
+
+      # Supported events
+      allow(message).to receive(:message).and_return("Source.create")
+      subject.send(:listener)
+      allow(message).to receive(:message).and_return("Application.create")
+      subject.send(:listener)
+
+      assert_process_event_calls_count(2)
+    end
+
+    it "start sync only once for subsequent events" do
+      expect(worker).to receive(:make_openshift_match_database).twice
+
+      skip_sync_duration = 1.second
+      stub_const("#{subject.class.name}::SKIP_SUBSEQUENT_EVENTS_DURATION", skip_sync_duration)
+
+      2.times do
+        allow(message).to receive(:message).and_return("Source.create")
+        subject.send(:listener)
+        allow(message).to receive(:message).and_return("Endpoint.create")
+        subject.send(:listener)
+        allow(message).to receive(:message).and_return("Authentication.create")
+        subject.send(:listener)
+
+        sleep(skip_sync_duration)
+      end
+    end
+  end
+
+  def stub_process_event
+    allow(subject).to receive(:process_event) do
+      @mutex.synchronize { @sync_invoked += 1; @cv.wait(@mutex) }
+    end
+  end
+
+  def assert_process_event_calls_count(expected_cnt)
+    called = false
+    until called
+      @mutex.synchronize { called = expected_cnt == @sync_invoked }
+    end
+    @cv.broadcast
+    expect(expected_cnt).to eq(@sync_invoked)
+  end
+end


### PR DESCRIPTION
By Kafka's queue `platform.sources.event-stream`

Sources API generates events *create*, *update*, *destroy* on `Source`, `Endpoint`, `Authentication` and `Application`. 

Full sync is started with any of these events.  
Because of UI is updating whole source (Source,Endpoint,Authentication) at the same time, multiple events are generated. Thus orchestrator ignores events which came 5 seconds since first one.

If no event is cought during 1 hour, orchestrator generates `Orchestrator.sync` event which invokes the same as standard event ^^^.

`NO_KAFKA` env variable disables event-driven a switches back to each-10-seconds sync

---

- [x] **depends on** https://github.com/RedHatInsights/e2e-deploy/pull/615