### PR TITLE
Prevent an exception on one source to kill the whole orchestrator

### DIFF
--- a/lib/topological_inventory/orchestrator/api.rb
+++ b/lib/topological_inventory/orchestrator/api.rb
@@ -106,6 +106,9 @@ module TopologicalInventory
         JSON.parse(
           RestClient.get(url, tenant_header(tenant_account))
         )
+      rescue RestClient::Exception => e
+        logger.error("Failed to get #{url}: #{e}")
+        raise
       rescue RestClient::NotFound
         nil
       end


### PR DESCRIPTION
Prevent an exception hit on a single source taking down the whole
orchestrator.  Also improve logging of get_and_parse if we hit a
RestClient::Exception.