### PR TITLE
Don't re-raise RestClient::RecordNotFound

### DIFF
--- a/lib/topological_inventory/orchestrator/api.rb
+++ b/lib/topological_inventory/orchestrator/api.rb
@@ -110,11 +110,11 @@ module TopologicalInventory
         JSON.parse(
           RestClient.get(url, tenant_header(tenant_account))
         )
+      rescue RestClient::NotFound
+        nil
       rescue RestClient::Exception => e
         logger.error("Failed to get #{url}: #{e}")
         raise
-      rescue RestClient::NotFound
-        nil
       end
 
       def tenant_header(tenant_account)


### PR DESCRIPTION
Mixed up the order which we catch the RecordNotFound exception