### PR TITLE
Lock down http gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,17 +3,17 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
+gem "activesupport", "~>5.2.2"
 gem "cloudwatchlogger", "~>0.2"
 gem "config", "~> 1.7.2"
 gem "http", "~> 4.1.1"
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.4"
-gem 'manageiq-messaging',   '~> 0.1.5'
+gem "manageiq-messaging",   '~> 0.1.5'
 gem "more_core_extensions", "~>3.7.0"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rest-client", "~>2.0"
-gem "activesupport", "~>5.2.2"
 
 group :test do
   gem "rake", "~> 10.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem "cloudwatchlogger", "~>0.2"
 gem "config", "~> 1.7.2"
+gem "http", "~> 4.1.1"
 gem "kubeclient", "~>4.0"
 gem "manageiq-loggers", "~>0.4"
 gem 'manageiq-messaging',   '~> 0.1.5'


### PR DESCRIPTION
Fixes:
```
irb(main):001:0> require 'http-parser'
Traceback (most recent call last):
       11: from /usr/local/bin/irb:11:in `<main>'
       10: from (irb):1
        9: from /usr/local/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:39:in `require'
        8: from /usr/local/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        7: from /usr/local/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `require'
        6: from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser.rb:5:in `<top (required)>'
        5: from /usr/local/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        4: from /usr/local/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        3: from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser/ext.rb:6:in `<top (required)>'
        2: from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser/ext.rb:8:in `<module:HttpParser>'
        1: from /usr/local/lib/ruby/gems/2.5.0/gems/ffi-compiler-1.0.1/lib/ffi-compiler/loader.rb:21:in `find'
LoadError (cannot find 'http-parser-ext' library)
```